### PR TITLE
feat: Add maskable icon and update PWA splash screen

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
 	"short_name": "AdaMeter",
 	"start_url": "/feeding",
 	"display": "standalone",
-	"background_color": "#fff",
+	"background_color": "#faf7ee",
 	"theme_color": "#000",
 	"icons": [
 		{
@@ -45,6 +45,12 @@
 			"src": "/icon-512x512.png",
 			"sizes": "512x512",
 			"type": "image/png"
+		},
+		{
+			"src": "/icon-512x512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "maskable"
 		}
 	]
 }


### PR DESCRIPTION
This commit introduces a maskable icon to the PWA configuration and updates the background color in the manifest.json.

Changes:
- Added a new entry to the `icons` array in `public/manifest.json` for `icon-512x512.png` with `"purpose": "maskable"`. This will ensure the icon adapts better to different platform masking shapes.
- Changed `background_color` in `public/manifest.json` to `#faf7ee` to be used for the PWA splash screen background, based on your input regarding the icon's own background color.
- Kept `theme_color` as `#000` for good contrast.

These changes improve the PWA's appearance by providing a dedicated maskable icon and configuring a suitable background color for the splash screen, addressing the issue of the icon appearing as a square on a white background.