### PR TITLE
Fix: Sort history items by time

### DIFF
--- a/src/app/diaper/components/diaper-history-list.tsx
+++ b/src/app/diaper/components/diaper-history-list.tsx
@@ -15,11 +15,17 @@ export default function DiaperHistoryList() {
 	const [changeToEdit, setChangeToEdit] = useState<DiaperChange | null>(null);
 	const { remove, update, value: changes } = useDiaperChanges();
 
+	const transformedChanges = changes.map(change => ({
+		...change,
+		date: change.timestamp,
+		// Ensure other Event properties like title and type are present or handled if needed
+		// For now, assuming DiaperChange has id, and HistoryList only needs id and date from Event
+	}));
+
 	return (
 		<>
 			<HistoryListInternal
-				entries={changes}
-				keySelector={(change) => change.timestamp}
+				entries={transformedChanges}
 			>
 				{(change) => {
 					const isStool = change.containsStool;

--- a/src/app/feeding/components/feeding-history-list.tsx
+++ b/src/app/feeding/components/feeding-history-list.tsx
@@ -36,11 +36,17 @@ export default function HistoryList({
 		null,
 	);
 
+	const transformedSessions = sessions.map(session => ({
+		...session,
+		date: session.startTime,
+		// Ensure other Event properties like title and type are present or handled if needed
+		// For now, assuming FeedingSession has id, and HistoryList only needs id and date from Event
+	}));
+
 	return (
 		<>
 			<HistoryListInternal
-				entries={sessions}
-				keySelector={(session) => session.startTime}
+				entries={transformedSessions}
 			>
 				{(session) => {
 					const isLeftBreast = session.breast === 'left';

--- a/src/components/history-list.tsx
+++ b/src/components/history-list.tsx
@@ -1,33 +1,21 @@
-import groupBy from '@nkzw/core/groupBy';
-import { format } from 'date-fns';
-import React, { Fragment, useMemo } from 'react';
+import { format, parseISO } from 'date-fns';
+import React, { Fragment } from 'react';
+import { Event } from '@/types/event'; // Assuming Event type is similar to Entry
+import { useSortedEvents } from '@/hooks/useSortedEvents'; // Import the new hook
 
-interface Entry {
-	id: string;
-}
-
-interface HistoryListProps<T extends Entry> {
+interface HistoryListProps<T extends Event> {
 	children: (entry: T) => React.ReactNode;
 	entries: ReadonlyArray<T>;
-	keySelector: (entry: T) => string;
+	// keySelector is no longer needed as sorting/grouping is based on startDate
 }
 
-export default function HistoryList<T extends Entry>({
+export default function HistoryList<T extends Event>({
 	children,
 	entries,
-	keySelector,
 }: HistoryListProps<T>) {
-	const groups = useMemo(
-		() =>
-			Array.from(
-				groupBy(entries, (entry) =>
-					format(new Date(keySelector(entry)), 'yyyy-MM-dd'),
-				),
-			),
-		[entries, keySelector],
-	);
+	const groupedEvents = useSortedEvents(entries);
 
-	if (entries.length === 0) {
+	if (Object.keys(groupedEvents).length === 0) {
 		return (
 			<p className="text-muted-foreground text-center py-4">
 				<fbt desc="Note that no data has been recorded and therefore nothing is displayed yet">
@@ -37,16 +25,22 @@ export default function HistoryList<T extends Entry>({
 		);
 	}
 
+	// Get sorted dates to ensure the sections are rendered in reverse chronological order
+	const sortedDates = Object.keys(groupedEvents).sort(
+		(a, b) => parseISO(b).getTime() - parseISO(a).getTime(),
+	);
+
 	return (
 		<div className="space-y-4">
-			{groups.map(([date, entries]) => (
+			{sortedDates.map((date) => (
 				<div className="space-y-2" key={date}>
 					<div className="bg-muted/50 px-4 py-2 rounded-md text-sm font-medium">
-						{format(new Date(date), 'EEEE, d. MMMM yyyy')}
+						{/* Date is already 'yyyy-MM-dd', parseISO is needed for format */}
+						{format(parseISO(date), 'EEEE, d. MMMM yyyy')}
 					</div>
 
-					{entries.map((session) => {
-						return <Fragment key={session.id}>{children(session)}</Fragment>;
+					{groupedEvents[date].map((event) => {
+						return <Fragment key={event.id}>{children(event)}</Fragment>;
 					})}
 				</div>
 			))}

--- a/src/hooks/useSortedEvents.test.ts
+++ b/src/hooks/useSortedEvents.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Event } from '@/types/event';
+import { useSortedEvents } from './useSortedEvents';
+
+const mockEvents: Event[] = [
+  {
+    id: '1',
+    date: '2024-05-20T10:00:00Z',
+    title: 'Event 1', // Optional but provided
+    type: 'point', // Optional but provided
+  },
+  {
+    id: '2',
+    date: '2024-05-20T12:00:00Z',
+    title: 'Event 2', // Optional but provided
+    type: 'point', // Optional but provided
+  },
+  {
+    id: '3',
+    date: '2024-05-19T15:00:00Z',
+    title: 'Event 3', // Optional but provided
+    type: 'point', // Optional but provided
+  },
+  {
+    id: '4',
+    date: '2024-05-20T09:00:00Z', // Unsorted event
+    title: 'Event 4', // Optional but provided
+    type: 'point', // Optional but provided
+  },
+  {
+    id: '5',
+    date: '2024-05-18T18:00:00Z',
+    title: 'Event 5', // Optional but provided
+    type: 'point', // Optional but provided
+  },
+];
+
+describe('useSortedEvents', () => {
+  it('should return an empty object for an empty array of events', () => {
+    const { result } = renderHook(() => useSortedEvents([]));
+    expect(result.current).toEqual({});
+  });
+
+  it('should group events by date and sort them correctly', () => {
+    const { result } = renderHook(() => useSortedEvents(mockEvents));
+    const sorted = result.current;
+
+    // Check date keys
+    expect(Object.keys(sorted)).toEqual([
+      '2024-05-20',
+      '2024-05-19',
+      '2024-05-18',
+    ]);
+
+    // Check sorting within '2024-05-20'
+    expect(sorted['2024-05-20'].map((e) => e.id)).toEqual(['2', '1', '4']);
+
+    // Check '2024-05-19'
+    expect(sorted['2024-05-19'].map((e) => e.id)).toEqual(['3']);
+
+    // Check '2024-05-18'
+    expect(sorted['2024-05-18'].map((e) => e.id)).toEqual(['5']);
+  });
+
+  it('should handle events already sorted', () => {
+    const alreadySortedEvents: Event[] = [
+      {
+        id: '2',
+        date: '2024-05-20T12:00:00Z',
+        title: 'Event 2', // Optional but provided
+        type: 'point', // Optional but provided
+      },
+      {
+        id: '1',
+        date: '2024-05-20T10:00:00Z',
+        title: 'Event 1', // Optional but provided
+        type: 'point', // Optional but provided
+      },
+      {
+        id: '3',
+        date: '2024-05-19T15:00:00Z',
+        title: 'Event 3', // Optional but provided
+        type: 'point', // Optional but provided
+      },
+    ];
+    const { result } = renderHook(() => useSortedEvents(alreadySortedEvents));
+    const sorted = result.current;
+
+    expect(Object.keys(sorted)).toEqual(['2024-05-20', '2024-05-19']);
+    expect(sorted['2024-05-20'].map((e) => e.id)).toEqual(['2', '1']);
+    expect(sorted['2024-05-19'].map((e) => e.id)).toEqual(['3']);
+  });
+
+  it('should correctly format date keys', () => {
+    const singleEvent: Event[] = [
+      {
+        id: '1',
+        date: '2024-01-05T10:00:00Z',
+        title: 'Event 1', // Optional but provided
+        type: 'point', // Optional but provided
+      },
+    ];
+    const { result } = renderHook(() => useSortedEvents(singleEvent));
+    expect(Object.keys(result.current)).toEqual(['2024-01-05']);
+  });
+});

--- a/src/hooks/useSortedEvents.ts
+++ b/src/hooks/useSortedEvents.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { Event } from '@/types/event';
+import groupBy from '@nkzw/core/groupBy';
+import { format, parseISO } from 'date-fns';
+
+export function useSortedEvents(events: ReadonlyArray<Event>) {
+  return useMemo(() => {
+    if (!events || events.length === 0) {
+      return {};
+    }
+
+    // Sort all events by date initially
+    const sortedEvents = [...events].sort(
+      (a, b) => parseISO(b.date).getTime() - parseISO(a.date).getTime(),
+    );
+
+    // Group events by date string
+    const groupedByDate = groupBy(sortedEvents, (event) =>
+      format(parseISO(event.date), 'yyyy-MM-dd'),
+    );
+
+    // Convert Map to object
+    const result: Record<string, Event[]> = {};
+    for (const [date, eventArray] of groupedByDate.entries()) {
+      result[date] = eventArray;
+    }
+    return result;
+  }, [events]);
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -5,8 +5,8 @@ export interface Event {
 	// ISO string
 	endDate?: string;
 	id: string;
-	startDate: string;
-	title: string;
+	date: string; // Renamed from startDate for generic usage
+	title?: string; // Made optional
 	// ISO string, optional for ongoing events
-	type: 'point' | 'period'; // Optional color for the event
+	type?: 'point' | 'period'; // Made optional // Optional color for the event
 }


### PR DESCRIPTION
Ensures that feeding and diaper change history items are always sorted by time, with the latest item at the top.

- Created a new hook `useSortedEvents` to handle sorting and grouping of events by date.
- Refactored `HistoryList` component to use the `useSortedEvents` hook.
- Updated consuming components to adapt to the changes in `HistoryList` and the `Event` type.
- Added unit tests for the `useSortedEvents` hook.