### PR TITLE
Feat: Add useLatestFeedingSession and update consumers

### DIFF
--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -3,8 +3,8 @@
 import Image from 'next/image';
 import '@/i18n';
 import Link from 'next/link';
-import { useDiaperChanges } from '@/hooks/use-diaper-changes';
-import { useFeedingSessions } from '@/hooks/use-feeding-sessions';
+import { useLatestDiaperChange } from '@/hooks/use-latest-diaper-change';
+import { useLatestFeedingSession } from '@/hooks/use-latest-feeding-session';
 import DataSharingSwitcher from './data-sharing-switcher';
 import LanguageSwitcher from './language-switcher';
 import Navigation from './navigation';
@@ -16,8 +16,8 @@ interface RootLayoutProps {
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {
-	const { value: sessions } = useFeedingSessions();
-	const { value: diaperChanges } = useDiaperChanges();
+	const latestFeedingSession = useLatestFeedingSession();
+	const latestDiaperChange = useLatestDiaperChange();
 
 	return (
 		<main className="flex min-h-screen flex-col items-center p-4 max-w-md mx-auto">
@@ -42,13 +42,13 @@ export default function RootLayout({ children }: RootLayoutProps) {
 			</div>
 
 			<div className="w-full flex flex-row justify-between gap-2 mb-6">
-				<TimeSince icon="🍼" lastChange={sessions[0]?.endTime || null}>
+				<TimeSince icon="🍼" lastChange={latestFeedingSession?.endTime || null}>
 					<fbt desc="Short label indicating when a feeding was last recorded">
 						Last Feeding
 					</fbt>
 				</TimeSince>
 
-				<TimeSince icon="👶" lastChange={diaperChanges[0]?.timestamp || null}>
+				<TimeSince icon="👶" lastChange={latestDiaperChange?.timestamp || null}>
 					<fbt desc="A short label indicating when a diaper was last changed">
 						Last Diaper Change
 					</fbt>

--- a/src/hooks/use-last-used-diaper-brand.ts
+++ b/src/hooks/use-last-used-diaper-brand.ts
@@ -1,6 +1,6 @@
-import { useDiaperChanges } from './use-diaper-changes';
+import { useLatestDiaperChange } from './use-latest-diaper-change';
 
 export const useLastUsedDiaperBrand = () => {
-	const { value: diaperChanges } = useDiaperChanges();
-	return diaperChanges[0]?.diaperBrand ?? 'andere';
+	const latestDiaperChange = useLatestDiaperChange();
+	return latestDiaperChange?.diaperBrand ?? 'andere';
 };

--- a/src/hooks/use-latest-diaper-change.test.ts
+++ b/src/hooks/use-latest-diaper-change.test.ts
@@ -1,0 +1,191 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DiaperChange } from '@/types/diaper';
+import { useDiaperChanges } from './use-diaper-changes';
+import { useLatestDiaperChange } from './use-latest-diaper-change';
+
+// Mock useDiaperChanges
+vi.mock('./use-diaper-changes', () => ({
+	useDiaperChanges: vi.fn(),
+}));
+
+const mockUseDiaperChanges = useDiaperChanges as vi.MockedFunction<
+	typeof useDiaperChanges
+>;
+
+describe('useLatestDiaperChange', () => {
+	it('should return undefined if there are no diaper changes', () => {
+		mockUseDiaperChanges.mockReturnValue({
+			value: [],
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toBeUndefined();
+	});
+
+	it('should return the diaper change if there is only one', () => {
+		const singleChange: DiaperChange = {
+			id: '1',
+			timestamp: '2023-01-01T12:00:00Z',
+			containsUrine: true,
+			containsStool: false,
+		};
+		mockUseDiaperChanges.mockReturnValue({
+			value: [singleChange],
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toEqual(singleChange);
+	});
+
+	it('should return the latest diaper change when newest is at the end', () => {
+		const changes: DiaperChange[] = [
+			{
+				id: '1',
+				timestamp: '2023-01-01T10:00:00Z',
+				containsUrine: true,
+				containsStool: false,
+			},
+			{
+				id: '2',
+				timestamp: '2023-01-01T11:00:00Z',
+				containsUrine: false,
+				containsStool: true,
+			},
+			{
+				id: '3',
+				timestamp: '2023-01-01T12:00:00Z',
+				containsUrine: true,
+				containsStool: true,
+			}, // Newest
+		];
+		mockUseDiaperChanges.mockReturnValue({
+			value: changes,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toEqual(changes[2]);
+	});
+
+	it('should return the latest diaper change when newest is at the beginning', () => {
+		const changes: DiaperChange[] = [
+			{
+				id: '3',
+				timestamp: '2023-01-01T12:00:00Z',
+				containsUrine: true,
+				containsStool: true,
+			}, // Newest
+			{
+				id: '1',
+				timestamp: '2023-01-01T10:00:00Z',
+				containsUrine: true,
+				containsStool: false,
+			},
+			{
+				id: '2',
+				timestamp: '2023-01-01T11:00:00Z',
+				containsUrine: false,
+				containsStool: true,
+			},
+		];
+		mockUseDiaperChanges.mockReturnValue({
+			value: changes,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toEqual(changes[0]);
+	});
+
+	it('should return the latest diaper change when newest is in the middle', () => {
+		const changes: DiaperChange[] = [
+			{
+				id: '1',
+				timestamp: '2023-01-01T10:00:00Z',
+				containsUrine: true,
+				containsStool: false,
+			},
+			{
+				id: '3',
+				timestamp: '2023-01-01T12:00:00Z',
+				containsUrine: true,
+				containsStool: true,
+			}, // Newest
+			{
+				id: '2',
+				timestamp: '2023-01-01T11:00:00Z',
+				containsUrine: false,
+				containsStool: true,
+			},
+		];
+		mockUseDiaperChanges.mockReturnValue({
+			value: changes,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toEqual(changes[1]);
+	});
+
+	it('should update when diaper changes array reference changes', () => {
+		const initialChanges: DiaperChange[] = [
+			{
+				id: '1',
+				timestamp: '2023-01-01T10:00:00Z',
+				containsUrine: true,
+				containsStool: false,
+			},
+		];
+		const nextChanges: DiaperChange[] = [
+			...initialChanges,
+			{
+				id: '2',
+				timestamp: '2023-01-01T11:00:00Z',
+				containsUrine: true,
+				containsStool: true,
+			}, // Newest
+		];
+
+		const mockDiaperChangesHook = mockUseDiaperChanges.mockReturnValue({
+			value: initialChanges,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result, rerender } = renderHook(() => useLatestDiaperChange());
+		expect(result.current).toEqual(initialChanges[0]);
+
+		act(() => {
+			mockDiaperChangesHook.mockReturnValue({
+				value: nextChanges,
+				add: vi.fn(),
+				remove: vi.fn(),
+				replace: vi.fn(),
+				update: vi.fn(),
+			});
+		});
+		rerender();
+
+		expect(result.current).toEqual(nextChanges[1]);
+	});
+});

--- a/src/hooks/use-latest-diaper-change.ts
+++ b/src/hooks/use-latest-diaper-change.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { DiaperChange } from '@/types/diaper';
+import { useDiaperChanges } from './use-diaper-changes';
+
+export function useLatestDiaperChange(): DiaperChange | undefined {
+	const { value: diaperChanges } = useDiaperChanges();
+
+	return useMemo(() => {
+		if (!diaperChanges || diaperChanges.length === 0) {
+			return undefined;
+		}
+
+		// Sort by timestamp in descending order and take the first element
+		// Timestamps are ISO strings, so string comparison works for finding the latest.
+		return [...diaperChanges].sort((a, b) => {
+			if (a.timestamp < b.timestamp) {
+				return 1;
+			}
+			if (a.timestamp > b.timestamp) {
+				return -1;
+			}
+			return 0;
+		})[0];
+	}, [diaperChanges]);
+}

--- a/src/hooks/use-latest-feeding-session.test.ts
+++ b/src/hooks/use-latest-feeding-session.test.ts
@@ -1,0 +1,203 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FeedingSession } from '@/types/feeding';
+import { useFeedingSessions } from './use-feeding-sessions';
+import { useLatestFeedingSession } from './use-latest-feeding-session';
+
+// Mock useFeedingSessions
+vi.mock('./use-feeding-sessions', () => ({
+	useFeedingSessions: vi.fn(),
+}));
+
+const mockUseFeedingSessions = useFeedingSessions as vi.MockedFunction<
+	typeof useFeedingSessions
+>;
+
+describe('useLatestFeedingSession', () => {
+	it('should return undefined if there are no feeding sessions', () => {
+		mockUseFeedingSessions.mockReturnValue({
+			value: [],
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toBeUndefined();
+	});
+
+	it('should return the feeding session if there is only one', () => {
+		const singleSession: FeedingSession = {
+			id: '1',
+			startTime: '2023-01-01T11:30:00Z',
+			endTime: '2023-01-01T12:00:00Z',
+			breast: 'left',
+			durationInSeconds: 1800,
+		};
+		mockUseFeedingSessions.mockReturnValue({
+			value: [singleSession],
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toEqual(singleSession);
+	});
+
+	it('should return the latest feeding session when newest (by endTime) is at the end', () => {
+		const sessions: FeedingSession[] = [
+			{
+				id: '1',
+				startTime: '2023-01-01T09:30:00Z',
+				endTime: '2023-01-01T10:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			},
+			{
+				id: '2',
+				startTime: '2023-01-01T10:30:00Z',
+				endTime: '2023-01-01T11:00:00Z',
+				breast: 'right',
+				durationInSeconds: 1800,
+			},
+			{
+				id: '3',
+				startTime: '2023-01-01T11:30:00Z',
+				endTime: '2023-01-01T12:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			}, // Latest
+		];
+		mockUseFeedingSessions.mockReturnValue({
+			value: sessions,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toEqual(sessions[2]);
+	});
+
+	it('should return the latest feeding session when newest (by endTime) is at the beginning', () => {
+		const sessions: FeedingSession[] = [
+			{
+				id: '3',
+				startTime: '2023-01-01T11:30:00Z',
+				endTime: '2023-01-01T12:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			}, // Latest
+			{
+				id: '1',
+				startTime: '2023-01-01T09:30:00Z',
+				endTime: '2023-01-01T10:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			},
+			{
+				id: '2',
+				startTime: '2023-01-01T10:30:00Z',
+				endTime: '2023-01-01T11:00:00Z',
+				breast: 'right',
+				durationInSeconds: 1800,
+			},
+		];
+		mockUseFeedingSessions.mockReturnValue({
+			value: sessions,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toEqual(sessions[0]);
+	});
+
+	it('should return the latest feeding session when newest (by endTime) is in the middle', () => {
+		const sessions: FeedingSession[] = [
+			{
+				id: '1',
+				startTime: '2023-01-01T09:30:00Z',
+				endTime: '2023-01-01T10:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			},
+			{
+				id: '3',
+				startTime: '2023-01-01T11:30:00Z',
+				endTime: '2023-01-01T12:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			}, // Latest
+			{
+				id: '2',
+				startTime: '2023-01-01T10:30:00Z',
+				endTime: '2023-01-01T11:00:00Z',
+				breast: 'right',
+				durationInSeconds: 1800,
+			},
+		];
+		mockUseFeedingSessions.mockReturnValue({
+			value: sessions,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toEqual(sessions[1]);
+	});
+
+	it('should update when feeding sessions array reference changes', () => {
+		const initialSessions: FeedingSession[] = [
+			{
+				id: '1',
+				startTime: '2023-01-01T09:30:00Z',
+				endTime: '2023-01-01T10:00:00Z',
+				breast: 'left',
+				durationInSeconds: 1800,
+			},
+		];
+		const nextSessions: FeedingSession[] = [
+			...initialSessions,
+			{
+				id: '2',
+				startTime: '2023-01-01T10:30:00Z',
+				endTime: '2023-01-01T11:00:00Z',
+				breast: 'right',
+				durationInSeconds: 1800,
+			}, // Latest
+		];
+
+		const mockHook = mockUseFeedingSessions.mockReturnValue({
+			value: initialSessions,
+			add: vi.fn(),
+			remove: vi.fn(),
+			replace: vi.fn(),
+			update: vi.fn(),
+		});
+
+		const { result, rerender } = renderHook(() => useLatestFeedingSession());
+		expect(result.current).toEqual(initialSessions[0]);
+
+		act(() => {
+			mockHook.mockReturnValue({
+				value: nextSessions,
+				add: vi.fn(),
+				remove: vi.fn(),
+				replace: vi.fn(),
+				update: vi.fn(),
+			});
+		});
+		rerender();
+
+		expect(result.current).toEqual(nextSessions[1]);
+	});
+});

--- a/src/hooks/use-latest-feeding-session.ts
+++ b/src/hooks/use-latest-feeding-session.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { FeedingSession } from '@/types/feeding';
+import { useFeedingSessions } from './use-feeding-sessions';
+
+export function useLatestFeedingSession(): FeedingSession | undefined {
+	const { value: feedingSessions } = useFeedingSessions();
+
+	return useMemo(() => {
+		if (!feedingSessions || feedingSessions.length === 0) {
+			return undefined;
+		}
+
+		// Create a shallow copy before sorting
+		const sortedSessions = [...feedingSessions].sort((a, b) => {
+			// Compare endTime strings directly (ISO format ensures correct chronological sorting)
+			if (a.endTime < b.endTime) {
+				return 1; // b is later
+			}
+			if (a.endTime > b.endTime) {
+				return -1; // a is later
+			}
+			return 0;
+		});
+
+		return sortedSessions[0];
+	}, [feedingSessions]);
+}

--- a/src/hooks/use-next-breast.ts
+++ b/src/hooks/use-next-breast.ts
@@ -1,6 +1,6 @@
-import { useFeedingSessions } from './use-feeding-sessions';
+import { useLatestFeedingSession } from './use-latest-feeding-session';
 
 export const useNextBreast = () => {
-	const { value: feedingSessions } = useFeedingSessions();
-	return (feedingSessions[0]?.breast ?? 'right') === 'left' ? 'right' : 'left';
+	const latestFeedingSession = useLatestFeedingSession();
+	return (latestFeedingSession?.breast ?? 'right') === 'left' ? 'right' : 'left';
 };


### PR DESCRIPTION
- Introduced `useLatestFeedingSession` hook to reliably get the feeding session with the most recent `endTime`.
- Added comprehensive unit tests for `useLatestFeedingSession`.
- Updated `RootLayout` to use `useLatestFeedingSession` for displaying "Last Feeding" time.
- Updated `useNextBreast` hook to use `useLatestFeedingSession` for correctly determining the next breast.
- Updated `RootLayout` to also use `useLatestDiaperChange` (from previous work on this branch) for "Last Diaper Change" time.

This ensures that components relying on the 'latest' diaper change or feeding session now correctly use the item with the most recent timestamp/endTime, rather than assuming the first item in the array is the latest.