### PR TITLE
fix(statistics): integrate HeatMap into stats grid for consistent spa…

### DIFF
--- a/src/app/statistics/components/heat-map.tsx
+++ b/src/app/statistics/components/heat-map.tsx
@@ -8,10 +8,11 @@ import {
 } from '@/components/ui/card';
 
 interface HeatMapProps {
+	className?: string;
 	sessions: FeedingSession[];
 }
 
-export default function HeatMap({ sessions = [] }: HeatMapProps) {
+export default function HeatMap({ className, sessions = [] }: HeatMapProps) {
 	// Ensure sessions is an array
 	const sessionsArray = Array.isArray(sessions) ? sessions : [];
 
@@ -69,7 +70,7 @@ export default function HeatMap({ sessions = [] }: HeatMapProps) {
 	});
 
 	return (
-		<Card>
+		<Card className={className}>
 			<CardHeader className="p-4 pb-2">
 				<CardTitle className="text-base">
 					<fbt desc="feedingDistribution">Daily Feeding Distribution</fbt>

--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -104,9 +104,8 @@ export default function StatisticsPage() {
 								<TimeBetweenStats sessions={filteredSessions} />
 								<FeedingsPerDayStats sessions={filteredSessions} />
 								<TotalFeedingsStats sessions={filteredSessions} />
+								<HeatMap className="col-span-2" sessions={filteredSessions} />
 							</div>
-
-							<HeatMap sessions={filteredSessions} />
 						</>
 					) : (
 						<div className="text-center py-4 text-muted-foreground">


### PR DESCRIPTION
…cing

The HeatMap component ("Tagesverteilung der Mahlzeiten") was previously rendered outside the main statistics card grid, leading to incorrect or missing vertical spacing between it and the cards above.

This change moves the HeatMap component into the primary grid container on the statistics page.
- The `HeatMap` is now a direct child of the `div` with `grid grid-cols-2 gap-4`.
- It has been assigned `className="col-span-2"` to ensure it spans the full width of the grid.
- The `HeatMap` component itself has been updated to accept and apply a `className` prop to its root `Card` element, allowing the grid styling to be correctly applied.