### PR TITLE
refactor: Update SplashScreen with manifest background and improved s…

### DIFF
--- a/src/components/splash-screen.tsx
+++ b/src/components/splash-screen.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Image from 'next/image';
+
+export function SplashScreen() {
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				top: 0,
+				left: 0,
+				width: '100vw',
+				height: '100vh',
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				backgroundColor: '#faf7ee', // From manifest.json
+				zIndex: 9999, // Ensure it's on top
+			}}
+		>
+			<Image
+				alt="AdaMeter Logo"
+				height={256}
+				src="/icon-512x512.png"
+				width={256}
+			/>
+		</div>
+	);
+}

--- a/src/contexts/yjs-context.tsx
+++ b/src/contexts/yjs-context.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { createContext, useCallback, useEffect, useState } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import { bind } from 'valtio-yjs';
+import { SplashScreen } from '@/components/splash-screen';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { Array, Doc, Map } from 'yjs';
 import { diaperChanges } from '@/data/diaper-changes';
@@ -27,7 +28,7 @@ export function YjsProvider({ children }: YjsProviderProps) {
 	useBindValtioToYjs(feedingInProgress, doc.getMap('feeding-in-progress'));
 
 	if (!isSynced) {
-		return <div>Loading...</div>;
+		return <SplashScreen />;
 	}
 
 	return <yjsContext.Provider value={{ doc }}>{children}</yjsContext.Provider>;


### PR DESCRIPTION
…tyling

- Sets SplashScreen background color from manifest.json (#faf7ee).
- Removes the text headline from the SplashScreen.
- Ensures SplashScreen covers the entire viewport and appears above other content using fixed positioning and z-index.