### PR TITLE
fix: Mitigate splash screen flicker and unify loading display

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 				<meta content="width=device-width, initial-scale=1" name="viewport" />
 				<link href="/manifest.json" rel="manifest" type="manifest" />
 			</head>
-			<body>
+			<body style={{ backgroundColor: '#faf7ee' }}>
 				<I18nProvider>
 					<ThemeProvider
 						attribute="class"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { useContext, useEffect, useState } from 'react';
+import { SplashScreen } from '@/components/splash-screen';
 import { I18nContext } from '@/contexts/i18n-context';
 import { useDiaperChanges } from '@/hooks/use-diaper-changes';
 import { useEvents } from '@/hooks/use-events';
@@ -85,5 +86,5 @@ export default function HomePage() {
 		redirect('/feeding');
 	}
 
-	return <div>Loading...</div>;
+	return <SplashScreen />;
 }

--- a/src/components/splash-screen.tsx
+++ b/src/components/splash-screen.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Image from 'next/image';
+
+export function SplashScreen() {
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				top: 0,
+				left: 0,
+				width: '100vw',
+				height: '100vh',
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				backgroundColor: '#faf7ee', // From manifest.json
+				zIndex: 9999, // Ensure it's on top
+			}}
+		>
+			<Image
+				alt="AdaMeter Logo"
+				height={256}
+				src="/icon-512x512.png"
+				width={256}
+			/>
+		</div>
+	);
+}

--- a/src/contexts/yjs-context.tsx
+++ b/src/contexts/yjs-context.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { createContext, useCallback, useEffect, useState } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import { bind } from 'valtio-yjs';
+import { SplashScreen } from '@/components/splash-screen';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { Array, Doc, Map } from 'yjs';
 import { diaperChanges } from '@/data/diaper-changes';
@@ -27,7 +28,7 @@ export function YjsProvider({ children }: YjsProviderProps) {
 	useBindValtioToYjs(feedingInProgress, doc.getMap('feeding-in-progress'));
 
 	if (!isSynced) {
-		return <div>Loading...</div>;
+		return <SplashScreen />;
 	}
 
 	return <yjsContext.Provider value={{ doc }}>{children}</yjsContext.Provider>;


### PR DESCRIPTION
- Sets body background color to match SplashScreen to reduce initial flicker.
- Replaces the "Loading..." text in `src/app/page.tsx` (data migration) with the `SplashScreen` component for a consistent loading experience.