### PR TITLE
feat: Add total feeding duration to statistics

### DIFF
--- a/src/app/statistics/components/total-duration-stats.tsx
+++ b/src/app/statistics/components/total-duration-stats.tsx
@@ -1,0 +1,49 @@
+import type { FeedingSession } from '@/types/feeding';
+import StatsCard from './stats-card';
+
+interface TotalDurationStatsProps {
+	sessions: FeedingSession[];
+}
+
+export default function TotalDurationStats({
+	sessions = [],
+}: TotalDurationStatsProps) {
+	// Ensure sessions is an array
+	const sessionsArray = Array.isArray(sessions) ? sessions : [];
+
+	if (sessionsArray.length === 0) return null;
+
+	// Calculate total duration
+	const totalDurationInSeconds = sessionsArray.reduce(
+		(sum, session) => sum + session.durationInSeconds,
+		0,
+	);
+
+	const formatTotalDuration = (totalSeconds: number) => {
+		const hours = Math.floor(totalSeconds / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+
+		const parts: string[] = [];
+		if (hours > 0) {
+			parts.push(`${hours} Std.`);
+		}
+		if (minutes > 0) {
+			parts.push(`${minutes} Min.`);
+		}
+		if (seconds > 0 || (hours === 0 && minutes === 0)) {
+			// Show seconds if there are seconds, or if hours and minutes are zero (e.g. "0 Sek.")
+			parts.push(`${seconds} Sek.`);
+		}
+
+		return parts.join(' ');
+	};
+
+	return (
+		<StatsCard title={<fbt desc="totalFeedingDuration">Total feeding duration</fbt>}>
+			<div className="text-2xl font-bold">
+				{formatTotalDuration(totalDurationInSeconds)}
+			</div>
+		</StatsCard>
+	);
+}

--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -20,6 +20,7 @@ import GrowthChart from './components/growth-chart';
 import HeatMap from './components/heat-map';
 import TimeBetweenStats from './components/time-between-stats';
 import TotalFeedingsStats from './components/total-feedings-stats';
+import TotalDurationStats from './components/total-duration-stats';
 
 export default function StatisticsPage() {
 	const { value: diaperChanges } = useDiaperChanges();
@@ -101,6 +102,7 @@ export default function StatisticsPage() {
 						<>
 							<div className="grid grid-cols-2 gap-4">
 								<DurationStats sessions={filteredSessions} />
+								<TotalDurationStats sessions={filteredSessions} />
 								<TimeBetweenStats sessions={filteredSessions} />
 								<FeedingsPerDayStats sessions={filteredSessions} />
 								<TotalFeedingsStats sessions={filteredSessions} />


### PR DESCRIPTION
- Creates a new statistics card to display the total duration of all feeding sessions.
- The duration is formatted as 'X Std. Y Min. Z Sek.'.
- The new card is placed next to the average feeding duration card.
- Updates translation files to include the new text for the card title.