### PR TITLE
Refactor: Remove unnecessary Array.isArray checks

### DIFF
--- a/src/app/growth/components/growth-list.tsx
+++ b/src/app/growth/components/growth-list.tsx
@@ -23,10 +23,7 @@ export default function GrowthMeasurementsList({
 	const [measurementToEdit, setMeasurementToEdit] =
 		useState<GrowthMeasurement | null>(null);
 
-	// Ensure measurements is an array
-	const measurementsArray = Array.isArray(measurements) ? measurements : [];
-
-	if (measurementsArray.length === 0) {
+	if (measurements.length === 0) {
 		return (
 			<p className="text-muted-foreground text-center py-4">
 				<fbt desc="noMeasurementsRecorded">No measurements recorded yet.</fbt>
@@ -42,7 +39,7 @@ export default function GrowthMeasurementsList({
 	};
 
 	// Sort measurements by date (newest first)
-	const sortedMeasurements = [...measurementsArray].sort(
+	const sortedMeasurements = [...measurements].sort(
 		(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
 	);
 

--- a/src/app/statistics/components/duration-stats.tsx
+++ b/src/app/statistics/components/duration-stats.tsx
@@ -7,10 +7,7 @@ interface DurationStatsProps {
 }
 
 export default function DurationStats({ sessions = [] }: DurationStatsProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
-
-	if (sessionsArray.length === 0) return null;
+	if (sessions.length === 0) return null;
 
 	// Calculate average durations
 	let totalDuration = 0;
@@ -19,7 +16,7 @@ export default function DurationStats({ sessions = [] }: DurationStatsProps) {
 	let leftCount = 0;
 	let rightCount = 0;
 
-	sessionsArray.forEach((session) => {
+	sessions.forEach((session) => {
 		totalDuration += session.durationInSeconds;
 		if (session.breast === 'left') {
 			leftDuration += session.durationInSeconds;
@@ -33,7 +30,7 @@ export default function DurationStats({ sessions = [] }: DurationStatsProps) {
 	const avgDuration = {
 		left: leftCount > 0 ? Math.round(leftDuration / leftCount) : 0,
 		right: rightCount > 0 ? Math.round(rightDuration / rightCount) : 0,
-		total: Math.round(totalDuration / sessionsArray.length),
+		total: Math.round(totalDuration / sessions.length),
 	};
 
 	return (

--- a/src/app/statistics/components/feedings-per-day-stats.tsx
+++ b/src/app/statistics/components/feedings-per-day-stats.tsx
@@ -9,14 +9,11 @@ interface FeedingsPerDayStatsProps {
 export default function FeedingsPerDayStats({
 	sessions = [],
 }: FeedingsPerDayStatsProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
-
-	if (sessionsArray.length === 0) return null;
+	if (sessions.length === 0) return null;
 
 	// Group sessions by day
 	const sessionsByDay = new Map<string, number>();
-	sessionsArray.forEach((session) => {
+	sessions.forEach((session) => {
 		const day = format(new Date(session.startTime), 'yyyy-MM-dd');
 		sessionsByDay.set(day, (sessionsByDay.get(day) || 0) + 1);
 	});

--- a/src/app/statistics/components/heat-map.tsx
+++ b/src/app/statistics/components/heat-map.tsx
@@ -13,15 +13,12 @@ interface HeatMapProps {
 }
 
 export default function HeatMap({ className, sessions = [] }: HeatMapProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
-
-	if (sessionsArray.length === 0) return null;
+	if (sessions.length === 0) return null;
 
 	// Calculate time distribution (5-minute intervals)
 	const distribution = Array(288).fill(0); // 288 5-minute intervals in a day
 
-	sessionsArray.forEach((session) => {
+	sessions.forEach((session) => {
 		const startTime = new Date(session.startTime);
 		const endTime = new Date(session.endTime);
 

--- a/src/app/statistics/components/time-between-stats.tsx
+++ b/src/app/statistics/components/time-between-stats.tsx
@@ -10,13 +10,10 @@ interface TimeBetweenStatsProps {
 export default function TimeBetweenStats({
 	sessions = [],
 }: TimeBetweenStatsProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
-
-	if (sessionsArray.length <= 1) return null;
+	if (sessions.length <= 1) return null;
 
 	// Sort sessions by start time (newest first)
-	const sortedSessions = [...sessionsArray].sort(
+	const sortedSessions = [...sessions].sort(
 		(a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime(),
 	);
 

--- a/src/app/statistics/components/total-duration-stats.tsx
+++ b/src/app/statistics/components/total-duration-stats.tsx
@@ -9,13 +9,10 @@ interface TotalDurationStatsProps {
 export default function TotalDurationStats({
 	sessions = [],
 }: TotalDurationStatsProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
-
-	if (sessionsArray.length === 0) return null;
+	if (sessions.length === 0) return null;
 
 	// Calculate total duration
-	const totalDurationInSeconds = sessionsArray.reduce(
+	const totalDurationInSeconds = sessions.reduce(
 		(sum, session) => sum + session.durationInSeconds,
 		0,
 	);

--- a/src/app/statistics/components/total-feedings-stats.tsx
+++ b/src/app/statistics/components/total-feedings-stats.tsx
@@ -8,13 +8,10 @@ interface TotalFeedingsStatsProps {
 export default function TotalFeedingsStats({
 	sessions = [],
 }: TotalFeedingsStatsProps) {
-	// Ensure sessions is an array
-	const sessionsArray = Array.isArray(sessions) ? sessions : [];
+	if (sessions.length === 0) return null;
 
-	if (sessionsArray.length === 0) return null;
-
-	const leftCount = sessionsArray.filter((s) => s.breast === 'left').length;
-	const rightCount = sessionsArray.filter((s) => s.breast === 'right').length;
+	const leftCount = sessions.filter((s) => s.breast === 'left').length;
+	const rightCount = sessions.filter((s) => s.breast === 'right').length;
 
 	return (
 		<StatsCard
@@ -24,7 +21,7 @@ export default function TotalFeedingsStats({
 				</fbt>
 			}
 		>
-			<div className="text-2xl font-bold">{sessionsArray.length}</div>
+			<div className="text-2xl font-bold">{sessions.length}</div>
 			<div className="text-xs text-muted-foreground mt-1">
 				<fbt desc="Label for the total number of feedings on the left breast">
 					Left Breast

--- a/src/utils/csv-export.ts
+++ b/src/utils/csv-export.ts
@@ -18,7 +18,7 @@ const escapeCSV = (field: string): string => {
 
 // Function to convert feeding sessions to CSV
 export const feedingSessionsToCsv = (sessions: FeedingSession[]): string => {
-	if (!Array.isArray(sessions) || sessions.length === 0) {
+	if (sessions.length === 0) {
 		return 'Brust,Startzeit,Endzeit,Dauer (Sekunden),Dauer (formatiert)\n';
 	}
 
@@ -53,7 +53,7 @@ export const feedingSessionsToCsv = (sessions: FeedingSession[]): string => {
 
 // Function to convert events to CSV
 export const eventsToCsv = (events: Event[]): string => {
-	if (!Array.isArray(events) || events.length === 0) {
+	if (events.length === 0) {
 		return 'Titel,Beschreibung,Startzeit,Endzeit,Typ,Farbe\n';
 	}
 
@@ -84,7 +84,7 @@ export const eventsToCsv = (events: Event[]): string => {
 export const growthMeasurementsToCsv = (
 	measurements: GrowthMeasurement[],
 ): string => {
-	if (!Array.isArray(measurements) || measurements.length === 0) {
+	if (measurements.length === 0) {
 		return 'Datum,Gewicht (g),Größe (cm),Notizen\n';
 	}
 
@@ -111,7 +111,7 @@ export const growthMeasurementsToCsv = (
 
 // Function to convert diaper changes to CSV
 export const diaperChangesToCsv = (changes: DiaperChange[]): string => {
-	if (!Array.isArray(changes) || changes.length === 0) {
+	if (changes.length === 0) {
 		return 'Zeitpunkt,Typ,Temperatur,Windelmarke,Ausgelaufen,Auffälligkeiten\n';
 	}
 
@@ -148,10 +148,10 @@ export const createJsonExport = (
 	diaperChanges: DiaperChange[],
 ): string => {
 	const exportData = {
-		diaperChanges: Array.isArray(diaperChanges) ? diaperChanges : [],
-		events: Array.isArray(events) ? events : [],
-		measurements: Array.isArray(measurements) ? measurements : [],
-		sessions: Array.isArray(sessions) ? sessions : [],
+		diaperChanges,
+		events,
+		measurements,
+		sessions,
 	};
 
 	return JSON.stringify(exportData, null, 2);


### PR DESCRIPTION
Removed redundant Array.isArray checks in components where TypeScript already guarantees the prop is an array due to type definitions and default prop values.

Specifically:
- Replaced `const arr = Array.isArray(prop) ? prop : []` with direct usage of `prop` in several functional components.
- Simplified conditions like `!Array.isArray(arr) || arr.length === 0` to `arr.length === 0` in utility functions where parameters are typed as arrays.

These changes simplify the codebase by removing defensive checks that are made redundant by TypeScript's static type checking, making the code cleaner and relying on the type system for correctness.

All existing tests pass after these changes.