### PR TITLE
Refactor LineChart data handling and labels

### DIFF
--- a/src/app/statistics/components/growth-chart.tsx
+++ b/src/app/statistics/components/growth-chart.tsx
@@ -2,9 +2,9 @@
 
 import type { Event } from '@/types/event';
 import type { GrowthMeasurement } from '@/types/growth';
-// Ensured fbt import is present
+import { fbt } from 'fbtee'; // Ensured fbt import is present
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import LineChart from './line-chart'; // Updated import name and path
+import LineChart from './line-chart';
 
 interface GrowthChartProps {
 	events?: Event[];
@@ -35,6 +35,25 @@ export default function GrowthChart({
 		);
 	}
 
+	const transformMeasurements = (
+		dataKey: keyof GrowthMeasurement,
+		currentMeasurements: GrowthMeasurement[],
+	) => {
+		return currentMeasurements
+			.filter((m) => m[dataKey] !== undefined && m[dataKey] !== null)
+			.map((m) => ({
+				x: new Date(m.date),
+				y: m[dataKey] as number,
+			}));
+	};
+
+	const weightData = transformMeasurements('weight', measurements);
+	const heightData = transformMeasurements('height', measurements);
+	const headCircumferenceData = transformMeasurements(
+		'headCircumference',
+		measurements,
+	);
+
 	return (
 		<Card>
 			<CardHeader className="p-4 pb-2">
@@ -46,38 +65,34 @@ export default function GrowthChart({
 				<LineChart
 					backgroundColor="rgba(99, 102, 241, 0.1)"
 					borderColor="#6366f1"
-					dataKey="weight"
+					chartData={weightData}
+					datasetLabel={fbt('Weight (g)', 'Dataset label for weight in grams')}
 					events={events}
-					label="Weight"
-					measurements={measurements}
-					title={<fbt desc="weightChartTitle">Weight (g)</fbt>}
-					unit="g"
+					title={<fbt desc="weightChartTitle">Weight</fbt>}
+					xAxisLabel={fbt('Date', 'X-axis label for date')}
+					noDataMessageLabel={fbt('Weight', 'Data type for no data message - weight')}
 				/>
 
 				<LineChart
 					backgroundColor="rgba(236, 72, 153, 0.1)"
 					borderColor="#ec4899"
-					dataKey="height"
+					chartData={heightData}
+					datasetLabel={fbt('Height (cm)', 'Dataset label for height in centimeters')}
 					events={events}
-					label="Height"
-					measurements={measurements}
-					title={<fbt desc="heightChartTitle">Height (cm)</fbt>}
-					unit="cm"
+					title={<fbt desc="heightChartTitle">Height</fbt>}
+					xAxisLabel={fbt('Date', 'X-axis label for date')}
+					noDataMessageLabel={fbt('Height', 'Data type for no data message - height')}
 				/>
 
 				<LineChart
 					backgroundColor="rgba(59, 130, 246, 0.1)" // Tailwind blue-500
 					borderColor="#3b82f6" // Tailwind blue-500
-					dataKey="headCircumference"
+					chartData={headCircumferenceData}
+					datasetLabel={fbt('Head Circumference (cm)', 'Dataset label for head circumference in centimeters')}
 					events={events}
-					label="Head Circumference"
-					measurements={measurements}
-					title={
-						<fbt desc="headCircumferenceChartTitle">
-							Head Circumference (cm)
-						</fbt>
-					}
-					unit="cm"
+					title={<fbt desc="headCircumferenceChartTitle">Head Circumference</fbt>}
+					xAxisLabel={fbt('Date', 'X-axis label for date')}
+					noDataMessageLabel={fbt('Head Circumference', 'Data type for no data message - head circumference')}
 				/>
 
 				{events.length > 0 && (

--- a/src/app/statistics/components/line-chart.test.tsx
+++ b/src/app/statistics/components/line-chart.test.tsx
@@ -4,15 +4,13 @@ import { render, screen } from '@testing-library/react';
 // Chart will be mocked
 import Chart from 'chart.js/auto'; // This import is fine, as vi.mock will handle it
 
-// fbt is used in defaultProps, ensure it's available or transformed by babel-plugin-fbtee
-// Added fbt import
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fbt } from 'fbtee';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'; // Added afterEach
+import { cleanup } from '@testing-library/react'; // Added cleanup
 
 // Import the component to test
-import LineChart from './line-chart'; // Corrected import
+import LineChart from './line-chart';
 
-// No longer mocking '../hooks/use-single-growth-chart' as logic is internal.
-// Instead, we may need to mock Chart.js itself if we want to inspect chart creation params.
 vi.mock('chart.js/auto', () => {
 	const mockChartInstance = {
 		destroy: vi.fn(),
@@ -26,20 +24,14 @@ vi.mock('chart.js/auto', () => {
 	return { default: mockChart };
 });
 
-// fbt will not be mocked, relying on actual fbtee behavior or babel transform.
-
-const mockMeasurementsFn = (): GrowthMeasurement[] => [
+const mockChartDataFn = () => [
 	{
-		date: '2023-01-01T00:00:00.000Z',
-		id: '1',
-		userId: 'user1',
-		weight: 3000,
+		x: new Date('2023-01-01T00:00:00.000Z'),
+		y: 3000,
 	},
 	{
-		date: '2023-01-08T00:00:00.000Z',
-		id: '2',
-		userId: 'user1',
-		weight: 3200,
+		x: new Date('2023-01-08T00:00:00.000Z'),
+		y: 3200,
 	},
 ];
 
@@ -48,116 +40,67 @@ const mockEventsFn = (): Event[] => [];
 const defaultPropsFn = () => ({
 	backgroundColor: 'rgba(0,0,255,0.1)',
 	borderColor: 'blue',
-	dataKey: 'weight' as keyof GrowthMeasurement,
+	chartData: mockChartDataFn(),
+	datasetLabel: 'Weight (g)',
 	events: mockEventsFn(),
-	label: 'Weight',
-	measurements: mockMeasurementsFn(),
 	title: <fbt desc="Test Chart Title">Test Chart</fbt>,
-	unit: 'g',
+	xAxisLabel: 'Date',
+	noDataMessageLabel: 'Weight',
 });
 
-describe('LineChart', () => { // Updated describe
+describe('LineChart', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
+	afterEach(() => {
+		cleanup(); // Cleanup after each test
+	});
+
 	it('renders the chart title', () => {
-		render(<LineChart {...defaultPropsFn()} />); // Updated component name
+		render(<LineChart {...defaultPropsFn()} />);
 		expect(screen.getByText('Test Chart')).toBeInTheDocument();
 	});
 
-	it('renders the canvas and initializes Chart when data is available', () => {
-		const { container } = render(<LineChart {...defaultPropsFn()} />); // Updated component name
+	it('renders the canvas and initializes Chart when chartData is available', () => {
+		const { container } = render(<LineChart {...defaultPropsFn()} />);
 		const canvasElement = container.querySelector('canvas');
 		expect(canvasElement).toBeInTheDocument();
 		expect(Chart).toHaveBeenCalled();
-		const chartArgs = (Chart as vi.Mock).mock.calls[0]; // vi.Mock for typed mock
+		const chartArgs = (Chart as vi.Mock).mock.calls[0];
 		expect(chartArgs[1].data.datasets[0].label).toBe('Weight (g)');
 		expect(chartArgs[1].data.datasets[0].data.length).toBe(2);
+		expect(chartArgs[1].options.scales.x.title.text).toBe('Date');
+		expect(chartArgs[1].options.scales.y.title.text).toBe('Weight (g)');
 	});
 
-	it('renders "no data" message when measurements for the dataKey are undefined', () => {
-		const props = {
-			...defaultPropsFn(),
-			measurements: mockMeasurementsFn().map((m) => ({
-				...m,
-				weight: undefined,
-			})),
-		};
-		const { container } = render(<LineChart {...props} />); // Updated component name
+	it('renders "no data" message when chartData array is empty', () => {
+		const props = { ...defaultPropsFn(), chartData: [] };
+		const { container } = render(<LineChart {...props} />);
 		expect(screen.getByText('No weight data available.')).toBeInTheDocument();
 		expect(container.querySelector('canvas')).not.toBeInTheDocument();
 		expect(Chart).not.toHaveBeenCalled();
 	});
 
-	it('renders "no data" message when measurements for the dataKey are null', () => {
-		const props = {
-			...defaultPropsFn(),
-			measurements: mockMeasurementsFn().map((m) => ({
-				...m,
-				weight: null as number | null | undefined,
-			})),
-		};
-		const { container } = render(<LineChart {...props} />); // Updated component name
-		expect(screen.getByText('No weight data available.')).toBeInTheDocument();
-		expect(container.querySelector('canvas')).not.toBeInTheDocument();
-		expect(Chart).not.toHaveBeenCalled();
-	});
-
-	it('renders "no data" message when measurements array is empty', () => {
-		const props = { ...defaultPropsFn(), measurements: [] };
-		const { container } = render(<LineChart {...props} />); // Updated component name
-		expect(screen.getByText('No weight data available.')).toBeInTheDocument();
-		expect(container.querySelector('canvas')).not.toBeInTheDocument();
-		expect(Chart).not.toHaveBeenCalled();
-	});
-
-	it('correctly determines hasData for different dataKeys and initializes chart', () => {
-		const propsWithHeight = {
-			...defaultPropsFn(),
-			dataKey: 'height' as keyof GrowthMeasurement,
-			label: 'Height',
-			measurements: [
-				{
-					date: '2023-01-01',
-					height: 50,
-					id: '1',
-					userId: 'user1',
-				} as GrowthMeasurement,
-				{
-					date: '2023-01-01',
-					id: '2',
-					userId: 'user1',
-					weight: 3000,
-				} as GrowthMeasurement,
-			],
-		};
-		const { container } = render(<LineChart {...propsWithHeight} />); // Updated component name
-		expect(container.querySelector('canvas')).toBeInTheDocument();
-		expect(Chart).toHaveBeenCalledTimes(1);
-		const chartArgsHeight = (Chart as vi.Mock).mock.calls[0];
-		expect(chartArgsHeight[1].data.datasets[0].label).toBe('Height (cm)');
-		expect(chartArgsHeight[1].data.datasets[0].data.length).toBe(1);
-
-		vi.clearAllMocks();
-
-		const propsWithNoHeightData = {
-			...propsWithHeight,
-			measurements: [
-				{
-					date: '2023-01-01',
-					id: '2',
-					userId: 'user1',
-					weight: 3000,
-				} as GrowthMeasurement,
-			],
-		};
-		const { container: containerNoHeight } = render(
-			<LineChart {...propsWithNoHeightData} />, // Updated component name
+	it('correctly passes event data to the chart', () => {
+		const eventsWithData: Event[] = [
+			{
+				color: '#ff0000',
+				endDate: '2023-01-05T00:00:00.000Z',
+				id: 'event1',
+				startDate: '2023-01-03T00:00:00.000Z',
+				title: 'Test Event',
+				type: 'period', // Added type to satisfy Event interface
+				userId: 'user1',
+			},
+		];
+		const props = { ...defaultPropsFn(), events: eventsWithData };
+		render(<LineChart {...props} />);
+		expect(Chart).toHaveBeenCalled();
+		const chartArgs = (Chart as vi.Mock).mock.calls[0];
+		const eventLinesPlugin = chartArgs[1].plugins.find(
+			(p: any) => p.id === 'eventLines',
 		);
-		expect(screen.getByText('No height data available.')).toBeInTheDocument();
-		expect(containerNoHeight.querySelector('canvas')).not.toBeInTheDocument();
-		// Chart mock should not have been called again since vi.clearAllMocks() and then no data render
-		expect(Chart).not.toHaveBeenCalled();
+		expect(eventLinesPlugin).toBeDefined();
 	});
 });


### PR DESCRIPTION
- Reverted unintended changes to package.json, pnpm-lock.yaml, and eslint.config.mjs.
- Restored original fbt descriptions in growth-chart.tsx.
- Refactored the LineChart component to accept pre-processed `chartData` ({ x: Date, y: number }[]) instead of `measurements` and `dataKey`.
- LineChart now accepts a single `datasetLabel` prop for the dataset and Y-axis, and an `xAxisLabel` prop.
- Updated `growth-chart.tsx` to transform measurement data before passing it to LineChart and to use the new label props with appropriate fbt calls.
- Updated LineChart tests to align with the new prop structure and data handling. Ensured all tests pass.
- Ran `pnpm install` to sync with the restored lockfile.
- Confirmed all project tests pass, indicating no regressions.