### PR TITLE
feat: Add unit tests for statistics cards

### DIFF
--- a/src/app/statistics/components/duration-stats.test.tsx
+++ b/src/app/statistics/components/duration-stats.test.tsx
@@ -1,0 +1,134 @@
+import type { FeedingSession } from '@/types/feeding';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { formatDurationAbbreviated } from '@/utils/format-duration-abbreviated'; // Using the real function
+import DurationStats from './duration-stats';
+
+// fbt mock removed
+// formatDurationAbbreviated mock removed
+
+const mockSessions: FeedingSession[] = [
+	{
+		breast: 'left',
+		durationInSeconds: 600,
+		endTime: new Date('2024-01-01T10:10:00Z').toISOString(), // 10 mins = 600s
+		id: '1',
+		notes: '',
+		startTime: new Date('2024-01-01T10:00:00Z').toISOString(),
+	},
+	{
+		breast: 'right',
+		durationInSeconds: 900,
+		endTime: new Date('2024-01-01T14:15:00Z').toISOString(), // 15 mins = 900s
+		id: '2',
+		notes: '',
+		startTime: new Date('2024-01-01T14:00:00Z').toISOString(),
+	},
+	{
+		breast: 'left',
+		durationInSeconds: 300,
+		endTime: new Date('2024-01-02T08:05:00Z').toISOString(), // 5 mins = 300s
+		id: '3',
+		notes: '',
+		startTime: new Date('2024-01-02T08:00:00Z').toISOString(),
+	},
+];
+
+describe('DurationStats', () => {
+	it('renders null when no sessions are provided', () => {
+		const { container } = render(<DurationStats sessions={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('calculates and displays average durations correctly', () => {
+		render(<DurationStats sessions={mockSessions} />);
+
+		// Total duration = 600 + 900 + 300 = 1800s
+		// Avg total duration = 1800s / 3 = 600s (Real: "10 min")
+		expect(screen.getByText('10 min')).toBeInTheDocument();
+
+		// Left breast: 600s + 300s = 900s. Avg = 900s / 2 = 450s (Real: "7 min")
+		// The real function likely rounds or truncates seconds if it's on the minute for abbreviated.
+		// Let's assume it shows "7 min" if it's exactly 7.5 minutes for abbreviation.
+		// If the real output is "7 min 30 s", this will need adjustment.
+		// For now, let's check what the actual output of formatDurationAbbreviated(450) is.
+		// If formatDurationAbbreviated(450) is "7 min 30 sec", then we use that.
+		// Based on prior test failures, it seems to abbreviate to the nearest minute or just minutes.
+		const avgLeftDuration =
+			(mockSessions[0].durationInSeconds + mockSessions[2].durationInSeconds) /
+			2; // (600 + 300) / 2 = 450
+		expect(
+			screen.getByText(formatDurationAbbreviated(avgLeftDuration)),
+		).toBeInTheDocument();
+
+		// Right breast: 900s. Avg = 900s / 1 = 900s (Real: "15 min")
+		expect(screen.getByText('15 min')).toBeInTheDocument();
+
+		expect(screen.getByText('Average Feeding Duration')).toBeInTheDocument();
+		expect(screen.getByText('Left Breast:')).toBeInTheDocument();
+		expect(screen.getByText('Right Breast:')).toBeInTheDocument();
+	});
+
+	it('handles sessions with only one breast type', () => {
+		const leftOnlySessions: FeedingSession[] = [
+			{
+				breast: 'left',
+				durationInSeconds: 600,
+				endTime: new Date().toISOString(),
+				id: '1',
+				notes: '',
+				startTime: new Date().toISOString(),
+			},
+			{
+				breast: 'left',
+				durationInSeconds: 300,
+				endTime: new Date().toISOString(),
+				id: '2',
+				notes: '',
+				startTime: new Date().toISOString(),
+			},
+		];
+		render(<DurationStats sessions={leftOnlySessions} />);
+
+		// Avg total: (leftOnlySessions[0].durationInSeconds + leftOnlySessions[1].durationInSeconds)/2 = 450s
+		// Avg left: 450s
+		// The actual output of formatDurationAbbreviated(450) is "7 min"
+		const avgDurationLeftOnly =
+			(leftOnlySessions[0].durationInSeconds +
+				leftOnlySessions[1].durationInSeconds) /
+			2;
+		expect(
+			screen.getAllByText(formatDurationAbbreviated(avgDurationLeftOnly))
+				.length,
+		).toBeGreaterThanOrEqual(2);
+
+		// Avg right: 0s (Real: "0 min" as per formatDurationAbbreviated(0))
+		expect(screen.getByText(formatDurationAbbreviated(0))).toBeInTheDocument();
+	});
+
+	it('handles sessions with zero duration', () => {
+		const zeroDurationSessions: FeedingSession[] = [
+			{
+				breast: 'left',
+				durationInSeconds: 0,
+				endTime: new Date().toISOString(),
+				id: '1',
+				notes: '',
+				startTime: new Date().toISOString(),
+			},
+			{
+				breast: 'right',
+				durationInSeconds: 0,
+				endTime: new Date().toISOString(),
+				id: '2',
+				notes: '',
+				startTime: new Date().toISOString(),
+			},
+		];
+		render(<DurationStats sessions={zeroDurationSessions} />);
+		// Avg total, left, right should all be 0s (Real: "0 min")
+		expect(
+			screen.getAllByText(formatDurationAbbreviated(0)).length,
+		).toBeGreaterThanOrEqual(3);
+	});
+});

--- a/src/app/statistics/components/feedings-per-day-stats.test.tsx
+++ b/src/app/statistics/components/feedings-per-day-stats.test.tsx
@@ -1,0 +1,99 @@
+import type { FeedingSession } from '@/types/feeding';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import FeedingsPerDayStats from './feedings-per-day-stats';
+
+const mockSessions: FeedingSession[] = [
+	{
+		breast: 'left',
+		durationInSeconds: 600,
+		endTime: new Date('2024-01-01T10:10:00Z').toISOString(),
+		id: '1',
+		notes: '',
+		startTime: new Date('2024-01-01T10:00:00Z').toISOString(), // Day 1
+	},
+	{
+		breast: 'right',
+		durationInSeconds: 900,
+		endTime: new Date('2024-01-01T14:15:00Z').toISOString(),
+		id: '2',
+		notes: '',
+		startTime: new Date('2024-01-01T14:00:00Z').toISOString(), // Day 1
+	},
+	{
+		breast: 'left',
+		durationInSeconds: 300,
+		endTime: new Date('2024-01-02T08:05:00Z').toISOString(),
+		id: '3',
+		notes: '',
+		startTime: new Date('2024-01-02T08:00:00Z').toISOString(), // Day 2
+	},
+	{
+		breast: 'right',
+		durationInSeconds: 600,
+		endTime: new Date('2024-01-03T12:10:00Z').toISOString(),
+		id: '4',
+		notes: '',
+		startTime: new Date('2024-01-03T12:00:00Z').toISOString(), // Day 3
+	},
+	{
+		breast: 'left',
+		durationInSeconds: 300,
+		endTime: new Date('2024-01-03T18:05:00Z').toISOString(),
+		id: '5',
+		notes: '',
+		startTime: new Date('2024-01-03T18:00:00Z').toISOString(), // Day 3
+	},
+]; // 5 sessions over 3 days. Day1: 2, Day2: 1, Day3: 2. Total 5. Avg = 5/3 = 1.666... -> 1.7
+
+describe('FeedingsPerDayStats', () => {
+	it('renders null when no sessions are provided', () => {
+		const { container } = render(<FeedingsPerDayStats sessions={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('calculates and displays average feedings per day correctly', () => {
+		render(<FeedingsPerDayStats sessions={mockSessions} />);
+
+		expect(screen.getByText('Feedings Per Day')).toBeInTheDocument();
+		expect(screen.getByText('1.7')).toBeInTheDocument(); // 5 sessions / 3 days
+	});
+
+	it('handles sessions all on the same day', () => {
+		const sameDaySessions: FeedingSession[] = [
+			{
+				breast: 'left',
+				durationInSeconds: 600,
+				endTime: new Date('2024-01-01T10:10:00Z').toISOString(),
+				id: '1',
+				notes: '',
+				startTime: new Date('2024-01-01T10:00:00Z').toISOString(),
+			},
+			{
+				breast: 'right',
+				durationInSeconds: 900,
+				endTime: new Date('2024-01-01T14:15:00Z').toISOString(),
+				id: '2',
+				notes: '',
+				startTime: new Date('2024-01-01T14:00:00Z').toISOString(),
+			},
+		]; // 2 sessions / 1 day
+		render(<FeedingsPerDayStats sessions={sameDaySessions} />);
+		expect(screen.getByText('2.0')).toBeInTheDocument();
+	});
+
+	it('handles a single session', () => {
+		const singleSession: FeedingSession[] = [
+			{
+				breast: 'left',
+				durationInSeconds: 600,
+				endTime: new Date('2024-01-01T10:10:00Z').toISOString(),
+				id: '1',
+				notes: '',
+				startTime: new Date('2024-01-01T10:00:00Z').toISOString(),
+			},
+		]; // 1 session / 1 day
+		render(<FeedingsPerDayStats sessions={singleSession} />);
+		expect(screen.getByText('1.0')).toBeInTheDocument();
+	});
+});

--- a/src/app/statistics/components/growth-chart.test.tsx
+++ b/src/app/statistics/components/growth-chart.test.tsx
@@ -1,0 +1,219 @@
+import type { Event } from '@/types/event';
+import type { GrowthMeasurement } from '@/types/growth';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import GrowthChart from './growth-chart';
+
+// Mock LineChart component
+interface MockLineChartProps {
+	backgroundColor: string;
+	borderColor: string;
+	data: Array<{ x: Date; y: number }>;
+	datasetLabel: { toString: () => string } | string;
+	emptyStateMessage: { toString: () => string } | string;
+	events: Event[];
+	title: { toString: () => string } | string;
+	xAxisLabel: { toString: () => string } | string;
+	yAxisLabel: { toString: () => string } | string;
+	yAxisUnit: string;
+}
+
+const mockLineChart = vi.fn();
+vi.mock('@/components/charts/line-chart', () => ({
+	default: (props: MockLineChartProps) => {
+		mockLineChart(props);
+		const titleString =
+			typeof props.title === 'string' ? props.title : props.title.toString();
+		return (
+			<div data-testid={`mock-line-chart-${titleString.toLowerCase()}`}>
+				{props.title} Chart - Data Length: {props.data.length}
+				{props.emptyStateMessage && props.data.length === 0
+					? props.emptyStateMessage.toString()
+					: null}
+			</div>
+		);
+	},
+}));
+
+const mockMeasurements: GrowthMeasurement[] = [
+	{
+		date: new Date('2024-01-01T00:00:00Z').toISOString(),
+		headCircumference: 35,
+		height: 50,
+		id: '1',
+		notes: '',
+		weight: 3000,
+	},
+	{
+		date: new Date('2024-01-15T00:00:00Z').toISOString(),
+		height: 52,
+		id: '2',
+		weight: 3500,
+		// No head circumference for this one
+	},
+	{
+		date: new Date('2024-01-08T00:00:00Z').toISOString(), // Out of order date
+		id: '3',
+		weight: 3200,
+		// No height
+		headCircumference: 36,
+	},
+];
+
+const mockEvents: Event[] = [
+	{
+		id: 'e1',
+		name: 'First Smile',
+		notes: '',
+		timestamp: new Date('2024-01-10T00:00:00Z').toISOString(),
+		type: 'milestone',
+	},
+];
+
+describe('GrowthChart', () => {
+	beforeEach(() => {
+		mockLineChart.mockClear();
+	});
+
+	it('renders no data message when no measurements are provided', () => {
+		render(<GrowthChart events={[]} measurements={[]} />);
+		expect(
+			screen.getByText(
+				'No measurements available. Add measurements to see the growth chart.',
+			),
+		).toBeInTheDocument();
+	});
+
+	it('renders titles for weight, height, and head circumference sections', () => {
+		render(<GrowthChart events={[]} measurements={mockMeasurements} />);
+		expect(screen.getByText('Weight (g)')).toBeInTheDocument();
+		expect(screen.getByText('Height (cm)')).toBeInTheDocument();
+		expect(screen.getByText('Head Circumference (cm)')).toBeInTheDocument();
+	});
+
+	it('passes sorted and filtered weight data to LineChart', () => {
+		render(<GrowthChart events={mockEvents} measurements={mockMeasurements} />);
+		const weightChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Weight',
+		);
+		expect(weightChartCall).toBeDefined();
+		expect(weightChartCall[0].data.length).toBe(3);
+		expect(weightChartCall[0].data[0].y).toBe(3000); // 2024-01-01
+		expect(weightChartCall[0].data[1].y).toBe(3200); // 2024-01-08
+		expect(weightChartCall[0].data[2].y).toBe(3500); // 2024-01-15
+		expect(weightChartCall[0].datasetLabel.toString()).toBe('Weight');
+		expect(weightChartCall[0].yAxisUnit).toBe('g');
+		expect(weightChartCall[0].events).toEqual(mockEvents);
+		const { container } = render(
+			<GrowthChart events={mockEvents} measurements={mockMeasurements} />,
+		);
+		const growthCard = container.firstChild as HTMLElement; // Assuming the card is the first child
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-weight'),
+		).toHaveTextContent('Weight Chart - Data Length: 3');
+	});
+
+	it('passes sorted and filtered height data to LineChart', () => {
+		const { container } = render(
+			<GrowthChart events={[]} measurements={mockMeasurements} />,
+		);
+		const growthCard = container.firstChild as HTMLElement;
+		const heightChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Height',
+		);
+		expect(heightChartCall).toBeDefined();
+		expect(heightChartCall[0].data.length).toBe(2);
+		expect(heightChartCall[0].data[0].y).toBe(50); // 2024-01-01
+		expect(heightChartCall[0].data[1].y).toBe(52); // 2024-01-15
+		expect(heightChartCall[0].datasetLabel.toString()).toBe('Height');
+		expect(heightChartCall[0].yAxisUnit).toBe('cm');
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-height'),
+		).toHaveTextContent('Height Chart - Data Length: 2');
+	});
+
+	it('passes sorted and filtered head circumference data to LineChart', () => {
+		const { container } = render(
+			<GrowthChart events={[]} measurements={mockMeasurements} />,
+		);
+		const growthCard = container.firstChild as HTMLElement;
+		const headChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Head Circumference',
+		);
+		expect(headChartCall).toBeDefined();
+		expect(headChartCall[0].data.length).toBe(2);
+		expect(headChartCall[0].data[0].y).toBe(35); // 2024-01-01
+		expect(headChartCall[0].data[1].y).toBe(36); // 2024-01-08
+		expect(headChartCall[0].datasetLabel.toString()).toBe('Head Circumference');
+		expect(headChartCall[0].yAxisUnit).toBe('cm');
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-head circumference'),
+		).toHaveTextContent('Head Circumference Chart - Data Length: 2');
+	});
+
+	it('displays empty state message for charts with no data', () => {
+		const singleMeasurement: GrowthMeasurement[] = [
+			{
+				date: new Date('2024-01-01T00:00:00Z').toISOString(),
+				id: '1',
+				// No weight, height, or headC data
+			},
+		];
+		const { container } = render(
+			<GrowthChart events={[]} measurements={singleMeasurement} />,
+		);
+		const growthCard = container.firstChild as HTMLElement;
+
+		const weightChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Weight',
+		);
+		expect(weightChartCall[0].data.length).toBe(0);
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-weight'),
+		).toHaveTextContent('No data available.');
+
+		const heightChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Height',
+		);
+		expect(heightChartCall[0].data.length).toBe(0);
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-height'),
+		).toHaveTextContent('No data available.');
+
+		const headChartCall = mockLineChart.mock.calls.find(
+			(call) => call[0].title.toString() === 'Head Circumference',
+		);
+		expect(headChartCall[0].data.length).toBe(0);
+		expect(
+			within(growthCard).getByTestId('mock-line-chart-head circumference'),
+		).toHaveTextContent('No data available.');
+	});
+
+	it('displays note about events when events are provided', () => {
+		const { container } = render(
+			<GrowthChart events={mockEvents} measurements={mockMeasurements} />,
+		);
+		const growthCard = container.firstChild as HTMLElement;
+		expect(
+			within(growthCard).getByText(
+				'* Vertical lines indicate important events.',
+			),
+		).toBeInTheDocument();
+	});
+
+	it('does not display note about events when no events are provided', () => {
+		const { container } = render(
+			<GrowthChart events={[]} measurements={mockMeasurements} />,
+		);
+		const growthCard = container.firstChild as HTMLElement;
+		expect(
+			within(growthCard).queryByText(
+				'* Vertical lines indicate important events.',
+			),
+		).not.toBeInTheDocument();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+});

--- a/src/app/statistics/components/heat-map.test.tsx
+++ b/src/app/statistics/components/heat-map.test.tsx
@@ -1,0 +1,170 @@
+import type { FeedingSession } from '@/types/feeding';
+import { cleanup, render, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import HeatMap from './heat-map';
+
+const mockSessions: FeedingSession[] = [
+	// Session 1: 00:00 - 00:09 (Intervals 0, 1)
+	{
+		breast: 'left',
+		durationInSeconds: 540,
+		endTime: new Date('2024-01-01T00:09:00Z').toISOString(), // Spans 2 5-min intervals (00:00, 00:05)
+		id: '1',
+		notes: '',
+		startTime: new Date('2024-01-01T00:00:00Z').toISOString(),
+	},
+	// Session 2: 00:05 - 00:14 (Intervals 1, 2)
+	{
+		breast: 'right',
+		durationInSeconds: 540,
+		endTime: new Date('2024-01-01T00:14:00Z').toISOString(), // Spans 2 5-min intervals (00:05, 00:10)
+		id: '2',
+		notes: '',
+		startTime: new Date('2024-01-01T00:05:00Z').toISOString(),
+	},
+	// Session 3: 23:55 - 00:04 (Intervals 287 (day 1), 0 (day 2))
+	{
+		breast: 'left',
+		durationInSeconds: 540,
+		endTime: new Date('2024-01-02T00:04:00Z').toISOString(), // Spans 2 5-min intervals (23:55 day 1, 00:00 day 2)
+		id: '3',
+		notes: '',
+		startTime: new Date('2024-01-01T23:55:00Z').toISOString(),
+	},
+];
+
+describe('HeatMap', () => {
+	it('renders null when no sessions are provided', () => {
+		const { container } = render(<HeatMap sessions={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders the heat map even with a single zero-duration session (maxCount > 0)', () => {
+		const singleZeroDurationSession: FeedingSession[] = [
+			{
+				breast: 'left',
+				durationInSeconds: 0,
+				endTime: new Date('2024-01-01T00:00:00Z').toISOString(), // Falls into 00:00 interval
+				id: '1',
+				notes: '',
+				startTime: new Date('2024-01-01T00:00:00Z').toISOString(),
+			},
+		];
+		const { container } = render(
+			<HeatMap sessions={singleZeroDurationSession} />,
+		);
+		const heatMapCard = container.firstChild as HTMLElement;
+		expect(heatMapCard).not.toBeNull();
+		expect(
+			within(heatMapCard).getByText('Daily Feeding Distribution'),
+		).toBeInTheDocument();
+	});
+
+	it('renders the heat map with correct number of interval divs', () => {
+		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const heatMapCard = container.firstChild as HTMLElement;
+		expect(
+			within(heatMapCard).getAllByText('Daily Feeding Distribution')[0],
+		).toBeInTheDocument();
+
+		// Find the heat map container more robustly
+		const intervalElementsContainer = within(heatMapCard).getByTitle(
+			'00:00 Uhr: 2 Mahlzeiten',
+		).parentElement;
+
+		expect(intervalElementsContainer).not.toBeNull();
+		if (intervalElementsContainer) {
+			expect(intervalElementsContainer.children.length).toBe(288); // 288 5-minute intervals
+		}
+	});
+
+	it('assigns correct titles (tooltips) to interval divs reflecting counts', () => {
+		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const heatMapCard = container.firstChild as HTMLElement;
+		// Interval 0 (00:00): Sessions 1 and 3 (midnight span) -> count 2
+		// Interval 1 (00:05): Sessions 1 and 2 -> count 2
+		// Interval 2 (00:10): Session 2 -> count 1
+		// Interval 287 (23:55): Session 3 -> count 1
+
+		const intervalElementsContainer = within(heatMapCard).getByTitle(
+			'00:00 Uhr: 2 Mahlzeiten',
+		).parentElement;
+
+		expect(intervalElementsContainer).not.toBeNull();
+		if (intervalElementsContainer) {
+			expect(intervalElementsContainer.children[0]).toHaveAttribute(
+				'title',
+				'00:00 Uhr: 2 Mahlzeiten',
+			);
+			expect(intervalElementsContainer.children[1]).toHaveAttribute(
+				'title',
+				'00:05 Uhr: 2 Mahlzeiten',
+			);
+			expect(intervalElementsContainer.children[2]).toHaveAttribute(
+				'title',
+				'00:10 Uhr: 1 Mahlzeit',
+			);
+			// ... other intervals would be "0 Mahlzeiten" or "1 Mahlzeit"
+			expect(intervalElementsContainer.children[287]).toHaveAttribute(
+				'title',
+				'23:55 Uhr: 1 Mahlzeit',
+			);
+		}
+	});
+
+	it('renders time markers and legend', () => {
+		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const heatMapCard = container.firstChild as HTMLElement;
+
+		// Use getAllByText for time markers as they might appear in tooltips too
+		expect(within(heatMapCard).getAllByText('00:00')[0]).toBeInTheDocument(); // Get the first instance, assuming it's the marker
+		expect(within(heatMapCard).getByText('03:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('06:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('09:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('12:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('15:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('18:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('21:00')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('24:00')).toBeInTheDocument();
+
+		expect(
+			within(heatMapCard).getByText('Very High Activity'),
+		).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('High Activity')).toBeInTheDocument();
+		expect(
+			within(heatMapCard).getByText('Medium Activity'),
+		).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('Low Activity')).toBeInTheDocument();
+		expect(
+			within(heatMapCard).getByText('Very Low Activity'),
+		).toBeInTheDocument();
+	});
+
+	it('applies different background colors based on intensity', () => {
+		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const heatMapCard = container.firstChild as HTMLElement;
+
+		// maxCount will be 2 for mockSessions
+		// Interval 0 (count 2): intensity 1.0 -> bg-pink-600
+		// Interval 2 (count 1): intensity 0.5 -> bg-purple-400 (0.4 <= intensity < 0.6)
+		// Interval 3 (count 0): intensity 0 -> bg-gray-100
+
+		const intervalElementsContainer = within(heatMapCard).getByTitle(
+			'00:00 Uhr: 2 Mahlzeiten',
+		).parentElement;
+
+		expect(intervalElementsContainer).not.toBeNull();
+		if (intervalElementsContainer) {
+			expect(intervalElementsContainer.children[0]).toHaveClass('bg-pink-600');
+			expect(intervalElementsContainer.children[1]).toHaveClass('bg-pink-600'); // count 2
+			expect(intervalElementsContainer.children[2]).toHaveClass(
+				'bg-purple-400',
+			); // count 1
+			expect(intervalElementsContainer.children[3]).toHaveClass('bg-gray-100'); // count 0
+		}
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+});

--- a/src/app/statistics/components/time-between-stats.test.tsx
+++ b/src/app/statistics/components/time-between-stats.test.tsx
@@ -1,0 +1,114 @@
+import type { FeedingSession } from '@/types/feeding';
+import { cleanup, render, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import TimeBetweenStats from './time-between-stats';
+
+// We are using the real formatDurationAbbreviated, so no need to import it here for mocking
+// import { formatDurationAbbreviated } from '@/utils/format-duration-abbreviated';
+
+// fbt mock removed
+// formatDurationAbbreviated mock removed - ensure no vi.mock for this utility is present
+
+const mockSessions: FeedingSession[] = [
+	{
+		// Session 1
+		breast: 'left',
+		durationInSeconds: 600,
+		endTime: new Date('2024-01-01T10:10:00Z').toISOString(),
+		id: '1',
+		notes: '',
+		startTime: new Date('2024-01-01T10:00:00Z').toISOString(), // Oldest
+	},
+	{
+		// Session 2: Diff from S1 = 2 hours (7200s)
+		breast: 'right',
+		durationInSeconds: 900,
+		endTime: new Date('2024-01-01T12:15:00Z').toISOString(),
+		id: '2',
+		notes: '',
+		startTime: new Date('2024-01-01T12:00:00Z').toISOString(),
+	},
+	{
+		// Session 3: Diff from S2 = 3 hours (10800s)
+		breast: 'left',
+		durationInSeconds: 300,
+		endTime: new Date('2024-01-01T15:05:00Z').toISOString(),
+		id: '3',
+		notes: '',
+		startTime: new Date('2024-01-01T15:00:00Z').toISOString(), // Newest
+	},
+];
+// Total time between = 7200s + 10800s = 18000s
+// Count = 2
+// Avg time between = 18000s / 2 = 9000s (2h 30m 0s by the real function)
+
+describe('TimeBetweenStats', () => {
+	// beforeEach can be removed if vi.clearAllMocks() is the only thing it did
+	// and vi is no longer used. For now, keeping it empty or removing it.
+	// beforeEach(() => {
+	// });
+
+	it('renders null when zero or one session is provided', () => {
+		const { container: zeroContainer } = render(
+			<TimeBetweenStats sessions={[]} />,
+		);
+		expect(zeroContainer.firstChild).toBeNull();
+
+		const { container: oneContainer } = render(
+			<TimeBetweenStats sessions={[mockSessions[0]]} />,
+		);
+		expect(oneContainer.firstChild).toBeNull();
+	});
+
+	it('calculates and displays average time between feedings correctly', () => {
+		const { container } = render(<TimeBetweenStats sessions={mockSessions} />);
+		const statsCard = container.firstChild as HTMLElement;
+		expect(
+			within(statsCard).getByText('Time Between Feedings'),
+		).toBeInTheDocument();
+		expect(within(statsCard).getByText('2 h 30 min')).toBeInTheDocument();
+	});
+
+	it('handles sessions with identical start times (0s difference)', () => {
+		const sessionsWithOverlap: FeedingSession[] = [
+			mockSessions[0], // 10:00
+			{ ...mockSessions[1], startTime: mockSessions[0].startTime }, // Also 10:00
+			mockSessions[2], // 15:00. Diff from 10:00 = 5 hours (18000s)
+		];
+		const { container } = render(
+			<TimeBetweenStats sessions={sessionsWithOverlap} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+		expect(within(statsCard).getByText('5 h')).toBeInTheDocument();
+	});
+
+	it('correctly sorts sessions by start time before calculating', () => {
+		const unsortedSessions: FeedingSession[] = [
+			mockSessions[1], // 12:00
+			mockSessions[2], // 15:00
+			mockSessions[0], // 10:00
+		];
+		const { container } = render(
+			<TimeBetweenStats sessions={unsortedSessions} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+		// This test might still be tricky if "2 h 30 min" is rendered by the first test case
+		// and cleanup isn't perfect or if this test rerenders it identically.
+		// The key is that THIS render call produces "2 h 30 min".
+		expect(within(statsCard).getByText('2 h 30 min')).toBeInTheDocument();
+	});
+
+	it('handles only two sessions', () => {
+		const twoSessions: FeedingSession[] = [
+			mockSessions[0], // 10:00
+			mockSessions[1], // 12:00. Diff = 7200s
+		];
+		const { container } = render(<TimeBetweenStats sessions={twoSessions} />);
+		const statsCard = container.firstChild as HTMLElement;
+		expect(within(statsCard).getByText('2 h')).toBeInTheDocument();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+});

--- a/src/app/statistics/components/total-duration-stats.test.tsx
+++ b/src/app/statistics/components/total-duration-stats.test.tsx
@@ -1,0 +1,68 @@
+import type { FeedingSession } from '@/types/feeding';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import TotalDurationStats from './total-duration-stats';
+
+// Using real formatDurationAbbreviated
+
+const mockSessions: FeedingSession[] = [
+	{
+		breast: 'left',
+		durationInSeconds: 600, // 10 mins
+		endTime: new Date().toISOString(),
+		id: '1',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+	{
+		breast: 'right',
+		durationInSeconds: 900, // 15 mins
+		endTime: new Date().toISOString(),
+		id: '2',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+	{
+		breast: 'left',
+		durationInSeconds: 300, // 5 mins
+		endTime: new Date().toISOString(),
+		id: '3',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+];
+// Total duration = 600 + 900 + 300 = 1800s (Actual output: "30m")
+
+describe('TotalDurationStats', () => {
+	// beforeEach removed
+
+	it('renders null when no sessions are provided', () => {
+		const { container } = render(<TotalDurationStats sessions={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('calculates and displays total feeding duration correctly', () => {
+		render(<TotalDurationStats sessions={mockSessions} />);
+		expect(screen.getByText('Total feeding duration')).toBeInTheDocument();
+		expect(screen.getByText('30 min')).toBeInTheDocument();
+	});
+
+	it('handles a single session', () => {
+		const singleSession = [mockSessions[0]]; // 600s
+		render(<TotalDurationStats sessions={singleSession} />);
+		expect(screen.getByText('10 min')).toBeInTheDocument();
+	});
+
+	it('handles sessions with zero duration', () => {
+		const zeroDurationSessions: FeedingSession[] = [
+			{ ...mockSessions[0], durationInSeconds: 0 },
+			{ ...mockSessions[1], durationInSeconds: 0 },
+		];
+		render(<TotalDurationStats sessions={zeroDurationSessions} />);
+		expect(screen.getByText('0 min')).toBeInTheDocument(); // Corrected to actual output "0 min"
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+});

--- a/src/app/statistics/components/total-feedings-stats.test.tsx
+++ b/src/app/statistics/components/total-feedings-stats.test.tsx
@@ -1,0 +1,181 @@
+import type { FeedingSession } from '@/types/feeding';
+import { cleanup, render, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import TotalFeedingsStats from './total-feedings-stats';
+
+const mockSessions: FeedingSession[] = [
+	{
+		breast: 'left',
+		durationInSeconds: 600,
+		endTime: new Date().toISOString(),
+		id: '1',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+	{
+		breast: 'right',
+		durationInSeconds: 900,
+		endTime: new Date().toISOString(),
+		id: '2',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+	{
+		breast: 'left',
+		durationInSeconds: 300,
+		endTime: new Date().toISOString(),
+		id: '3',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+	{
+		breast: 'bottle', // Should be ignored by left/right counts but included in total
+		durationInSeconds: 300,
+		endTime: new Date().toISOString(),
+		id: '4',
+		notes: '',
+		startTime: new Date().toISOString(),
+	},
+];
+// Total sessions: 4
+// Left: 2
+// Right: 1
+
+describe('TotalFeedingsStats', () => {
+	it('renders null when no sessions are provided', () => {
+		const { container } = render(<TotalFeedingsStats sessions={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('displays total feedings and counts for left/right breast correctly', () => {
+		render(<TotalFeedingsStats sessions={mockSessions} />);
+
+		const { container } = render(
+			<TotalFeedingsStats sessions={mockSessions} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+
+		expect(within(statsCard).getByText('Total Feedings')).toBeInTheDocument();
+		const totalFeedingsValue = within(statsCard).getByText(
+			(content, element) => {
+				return (
+					element?.tagName.toLowerCase() === 'div' &&
+					element.classList.contains('text-2xl') &&
+					content === '4'
+				);
+			},
+		);
+		expect(totalFeedingsValue).toBeInTheDocument();
+
+		const leftBreastLabelDiv = within(statsCard)
+			.getByText(/Left Breast:/)
+			.closest('div');
+		expect(leftBreastLabelDiv).toBeInTheDocument();
+		expect(within(leftBreastLabelDiv!).getByText('2')).toBeInTheDocument();
+
+		const rightBreastLabelDiv = within(statsCard)
+			.getByText(/Right Breast:/)
+			.closest('div');
+		expect(rightBreastLabelDiv).toBeInTheDocument();
+		expect(within(rightBreastLabelDiv!).getByText('1')).toBeInTheDocument();
+	});
+
+	it('handles sessions with only one breast type', () => {
+		const leftOnlySessions: FeedingSession[] = [
+			{ ...mockSessions[0], breast: 'left' },
+			{ ...mockSessions[2], breast: 'left' },
+		]; // Total 2, Left 2, Right 0
+		const { container } = render(
+			<TotalFeedingsStats sessions={leftOnlySessions} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+
+		const totalFeedingsValue = within(statsCard).getByText(
+			(content, element) => {
+				return (
+					element?.tagName.toLowerCase() === 'div' &&
+					element.classList.contains('text-2xl') &&
+					content === '2'
+				);
+			},
+		);
+		expect(totalFeedingsValue).toBeInTheDocument(); // Total count
+
+		const leftBreastLabelDiv = within(statsCard)
+			.getByText(/Left Breast:/)
+			.closest('div');
+		expect(within(leftBreastLabelDiv!).getByText('2')).toBeInTheDocument();
+
+		const rightBreastLabelDiv = within(statsCard)
+			.getByText(/Right Breast:/)
+			.closest('div');
+		expect(within(rightBreastLabelDiv!).getByText('0')).toBeInTheDocument();
+	});
+
+	it('handles sessions with no specific breast (e.g., bottle)', () => {
+		const bottleOnlySessions: FeedingSession[] = [
+			{ ...mockSessions[0], breast: 'bottle' },
+			{ ...mockSessions[1], breast: 'bottle' },
+		]; // Total 2, Left 0, Right 0
+		const { container } = render(
+			<TotalFeedingsStats sessions={bottleOnlySessions} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+
+		const totalFeedingsValue = within(statsCard).getByText(
+			(content, element) => {
+				return (
+					element?.tagName.toLowerCase() === 'div' &&
+					element.classList.contains('text-2xl') &&
+					content === '2'
+				);
+			},
+		);
+		expect(totalFeedingsValue).toBeInTheDocument(); // Total
+
+		const leftBreastLabelDiv = within(statsCard)
+			.getByText(/Left Breast:/)
+			.closest('div');
+		expect(within(leftBreastLabelDiv!).getByText('0')).toBeInTheDocument();
+
+		const rightBreastLabelDiv = within(statsCard)
+			.getByText(/Right Breast:/)
+			.closest('div');
+		expect(within(rightBreastLabelDiv!).getByText('0')).toBeInTheDocument();
+	});
+
+	it('handles a single session', () => {
+		const singleSession: FeedingSession[] = [
+			{ ...mockSessions[0], breast: 'right' },
+		]; // Total 1, Right 1, Left 0
+		const { container } = render(
+			<TotalFeedingsStats sessions={singleSession} />,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+
+		const totalFeedingsValue = within(statsCard).getByText(
+			(content, element) => {
+				return (
+					element?.tagName.toLowerCase() === 'div' &&
+					element.classList.contains('text-2xl') &&
+					content === '1'
+				);
+			},
+		);
+		expect(totalFeedingsValue).toBeInTheDocument(); // Total
+
+		const leftBreastLabelDiv = within(statsCard)
+			.getByText(/Left Breast:/)
+			.closest('div');
+		expect(within(leftBreastLabelDiv!).getByText('0')).toBeInTheDocument();
+
+		const rightBreastLabelDiv = within(statsCard)
+			.getByText(/Right Breast:/)
+			.closest('div');
+		expect(within(rightBreastLabelDiv!).getByText('1')).toBeInTheDocument();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+});


### PR DESCRIPTION
Adds Vitest unit tests for the following statistics card components:
- DurationStats
- FeedingsPerDayStats
- GrowthChart (mocks LineChart)
- HeatMap
- TimeBetweenStats
- TotalDurationStats
- TotalFeedingsStats

These tests cover rendering with and without data, calculation accuracy, and correct display of information.

Refactored tests to remove unnecessary mocks for fbt and duration formatting utilities, relying on actual component outputs. Improved query specificity and DOM cleanup practices.

Removed `diaper-stats.test.tsx` as per user instruction to defer testing for this component due to complexities with tab panel interactions in the test environment.