### PR TITLE
feat(contexts): add tests for YjsProvider

### DIFF
--- a/src/__mocks__/y-indexeddb.ts
+++ b/src/__mocks__/y-indexeddb.ts
@@ -1,0 +1,36 @@
+// Mock for y-indexeddb
+
+let currentResolveWhenSynced: () => void;
+let currentWhenSyncedPromise: Promise<void>;
+
+const setupNewWhenSynced = () => {
+	currentWhenSyncedPromise = new Promise<void>((resolve) => {
+		currentResolveWhenSynced = resolve;
+	});
+};
+
+setupNewWhenSynced(); // Initialize for the first import
+
+export const triggerWhenSynced = () => {
+	if (currentResolveWhenSynced) {
+		currentResolveWhenSynced();
+	} else {
+		// Optional: console.warn for debugging, but remove for final version
+		// console.warn('triggerWhenSynced called but currentResolveWhenSynced is not set.');
+	}
+};
+
+export const resetIndexeddbMock = () => {
+	setupNewWhenSynced();
+};
+
+export class IndexeddbPersistence {
+	public whenSynced: Promise<void>;
+
+	constructor(dbName: string, doc: unknown) {
+		this.whenSynced = currentWhenSyncedPromise;
+	}
+
+	// Add any other methods or properties that are used by yjs-context.tsx
+	// For now, it seems only `whenSynced` is directly used.
+}

--- a/src/contexts/yjs-context.test.tsx
+++ b/src/contexts/yjs-context.test.tsx
@@ -1,0 +1,125 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import React, { useContext, useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Array as YArray, Doc as YDoc, Map as YMap } from 'yjs';
+import {
+	resetIndexeddbMock,
+	triggerWhenSynced,
+} from '../__mocks__/y-indexeddb';
+import { yjsContext, YjsProvider } from './yjs-context';
+
+vi.mock('y-indexeddb');
+
+vi.mock('valtio-yjs', () => ({
+	bind: vi.fn(() => vi.fn()),
+}));
+
+describe('YjsProvider', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		resetIndexeddbMock();
+
+		const ValtioYjsMocked = await import('valtio-yjs');
+		(ValtioYjsMocked.bind as ReturnType<typeof vi.fn>).mockImplementation(() =>
+			vi.fn(),
+		);
+	});
+
+	it('should show SplashScreen initially and then render children after sync', async () => {
+		const InlineTestConsumer = () => {
+			const { doc } = useContext(yjsContext);
+			return <div data-testid="doc-id">{doc.guid}</div>;
+		};
+
+		const { getByAltText, queryByRole, queryByTestId } = render(
+			<YjsProvider>
+				<InlineTestConsumer />
+			</YjsProvider>,
+		);
+
+		expect(getByAltText('AdaMeter Logo')).toBeInTheDocument();
+		expect(queryByTestId('doc-id')).not.toBeInTheDocument();
+
+		await act(async () => {
+			triggerWhenSynced();
+		});
+
+		expect(
+			queryByRole('img', { name: 'AdaMeter Logo' }),
+		).not.toBeInTheDocument();
+		expect(queryByTestId('doc-id')).toBeInTheDocument();
+	});
+
+	it('should provide a Yjs.Doc instance through context', async () => {
+		let receivedDoc: YDoc | null = null;
+
+		const DocCapturingConsumer = () => {
+			const { doc } = useContext(yjsContext);
+			useEffect(() => {
+				receivedDoc = doc;
+			}, [doc]);
+			return <div data-testid="doc-captured">{doc?.guid}</div>;
+		};
+
+		render(
+			<YjsProvider>
+				<DocCapturingConsumer />
+			</YjsProvider>,
+		);
+
+		await act(async () => {
+			triggerWhenSynced();
+		});
+
+		expect(screen.getByTestId('doc-captured')).toBeInTheDocument();
+		expect(receivedDoc).not.toBeNull();
+		expect(receivedDoc).toBeInstanceOf(YDoc);
+		expect(receivedDoc?.guid).toBeTruthy();
+	});
+
+	it('should call bind for all data stores', async () => {
+		const ValtioYjsMocked = await import('valtio-yjs');
+		const diaperChangesData = await import('@/data/diaper-changes');
+		const eventsData = await import('@/data/events');
+		const feedingSessionsData = await import('@/data/feeding-sessions');
+		const growthMeasurementsData = await import('@/data/growth-measurments');
+		const feedingInProgressData = await import('@/data/feeding-in-progress');
+
+		// Render YjsProvider with a minimal child for this test
+		render(
+			<YjsProvider>
+				<div />
+			</YjsProvider>,
+		);
+
+		await act(async () => {
+			triggerWhenSynced();
+		});
+
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledWith(
+			diaperChangesData.diaperChanges,
+			expect.any(YArray),
+		);
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledWith(
+			eventsData.events,
+			expect.any(YArray),
+		);
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledWith(
+			feedingSessionsData.feedingSessions,
+			expect.any(YArray),
+		);
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledWith(
+			growthMeasurementsData.growthMeasurements,
+			expect.any(YArray),
+		);
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledWith(
+			feedingInProgressData.feedingInProgress,
+			expect.any(YMap),
+		);
+		expect(ValtioYjsMocked.bind).toHaveBeenCalledTimes(5);
+	});
+});


### PR DESCRIPTION
Adds comprehensive tests for the YjsProvider component in src/contexts/yjs-context.tsx.

The tests cover:
- Initial rendering of the actual SplashScreen component.
- Rendering of children after Yjs synchronization.
- Provision of a Y.Doc instance via context.
- Correct invocation of valtio-yjs `bind` for all relevant data stores.

A mock for `y-indexeddb` is introduced in `src/__mocks__` to facilitate testing the IndexedDB persistence aspects. The valtio-yjs `bind` function is also mocked.

Test structure was refined to:
- Not mock SplashScreen, asserting its actual presence.
- Simplify the valtio-yjs mock.
- Inline a test consumer component where it's uniquely used.
- Use a minimal child for tests focused on hook invocations.
- Remove AI-specific thought-process comments from the test file.

All pre-submission checks as per AGENTS.md have been successfully completed.