### PR TITLE
feat: Decouple MedicationAdministration and implement form

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		}
 	},
 	"dependencies": {
+		"@hookform/resolvers": "^5.1.1",
 		"@nkzw/core": "^1.2.0",
 		"@radix-ui/react-accordion": "^1.2.11",
 		"@radix-ui/react-alert-dialog": "^1.1.11",
@@ -31,6 +32,7 @@
 		"@radix-ui/react-dropdown-menu": "^2.1.12",
 		"@radix-ui/react-label": "^2.1.4",
 		"@radix-ui/react-navigation-menu": "^1.2.10",
+		"@radix-ui/react-popover": "^1.1.14",
 		"@radix-ui/react-radio-group": "^1.3.4",
 		"@radix-ui/react-select": "^2.2.2",
 		"@radix-ui/react-slot": "^1.2.0",
@@ -41,6 +43,7 @@
 		"chartjs-adapter-date-fns": "latest",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"cmdk": "^1.1.1",
 		"crypto-js": "^4.2.0",
 		"date-fns": "latest",
 		"fast-deep-equal": "^3.1.3",
@@ -52,6 +55,7 @@
 		"partysocket": "1.1.4",
 		"react": "^19",
 		"react-dom": "^19",
+		"react-hook-form": "^7.59.0",
 		"tailwind-merge": "^3.2.0",
 		"tailwindcss": "^4.1.4",
 		"tw-animate-css": "^1.2.8",
@@ -59,7 +63,8 @@
 		"valtio-yjs": "^0.6.0",
 		"y-indexeddb": "^9.0.12",
 		"y-partykit": "^0.0.33",
-		"yjs": "^13.6.27"
+		"yjs": "^13.6.27",
+		"zod": "^3.25.67"
 	},
 	"devDependencies": {
 		"@babel/runtime": "^7.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.1.1
+        version: 5.1.1(react-hook-form@7.59.0(react@19.1.0))
       '@nkzw/core':
         specifier: ^1.2.0
         version: 1.2.1
@@ -29,6 +32,9 @@ importers:
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.10
         version: 1.2.13(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.4
         version: 1.3.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -59,6 +65,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -92,6 +101,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.59.0
+        version: 7.59.0(react@19.1.0)
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.3.1
@@ -116,6 +128,9 @@ importers:
       yjs:
         specifier: ^13.6.27
         version: 13.6.27
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.67
     devDependencies:
       '@babel/runtime':
         specifier: ^7.27.0
@@ -837,6 +852,11 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@hookform/resolvers@5.1.1':
+    resolution: {integrity: sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1337,6 +1357,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.14':
+    resolution: {integrity: sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.7':
     resolution: {integrity: sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==}
     peerDependencies:
@@ -1659,6 +1692,9 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2307,6 +2343,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3766,6 +3808,12 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-hook-form@7.59.0:
+    resolution: {integrity: sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5082,6 +5130,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.59.0(react@19.1.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -5586,6 +5639,29 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-popover@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -5865,6 +5941,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -6595,6 +6673,18 @@ snapshots:
       wrap-ansi: 9.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:
@@ -8186,6 +8276,10 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-hook-form@7.59.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 

--- a/src/app/medication/components/medication-administration-form.tsx
+++ b/src/app/medication/components/medication-administration-form.tsx
@@ -1,0 +1,485 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { fbt } from 'fbtee';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from '@/components/ui/command';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { MedicationAdministration } from '@/types/medication';
+import { MedicationRegimen } from '@/types/medication-regimen';
+import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
+import { dateToTimeInputValue } from '@/utils/date-to-time-input-value';
+import {
+	MedicationAdministrationFormData,
+	medicationAdministrationSchema,
+} from '../validation/medication-administration-schema';
+
+interface MedicationAdministrationFormProps {
+	// To get unique one-off medication names for suggestions
+	allAdministrations: readonly MedicationAdministration[];
+	initialData?: MedicationAdministration;
+	isOpen: boolean;
+	onClose: () => void;
+	onSubmit: (data: MedicationAdministrationFormData, id?: string) => void;
+	regimens: readonly MedicationRegimen[];
+}
+
+interface ComboboxOption {
+	dosageAmount?: number;
+	dosageUnit?: string;
+	label: string; // medication name
+	regimenId?: string;
+	type: 'regimen' | 'one-off';
+	value: string; // medication name, or special value for regimen
+}
+
+export const MedicationAdministrationForm: React.FC<
+	MedicationAdministrationFormProps
+> = ({
+	allAdministrations,
+	initialData,
+	isOpen,
+	onClose,
+	onSubmit,
+	regimens,
+}) => {
+	const [datePart, setDatePart] = useState<string>(() =>
+		dateToDateInputValue(
+			initialData?.timestamp ? new Date(initialData.timestamp) : new Date(),
+		),
+	);
+	const [timePart, setTimePart] = useState<string>(() =>
+		dateToTimeInputValue(
+			initialData?.timestamp ? new Date(initialData.timestamp) : new Date(),
+		),
+	);
+	const [comboboxOpen, setComboboxOpen] = useState(false);
+
+	const form = useForm<MedicationAdministrationFormData>({
+		defaultValues: {
+			administrationStatus: initialData?.administrationStatus || 'On Time',
+			details: initialData?.details || '',
+			dosageAmount: initialData?.dosageAmount || undefined,
+			dosageUnit: initialData?.dosageUnit || '',
+			medicationName: initialData?.medicationName || '',
+			regimenId: initialData?.regimenId || undefined,
+			timestamp: initialData?.timestamp || new Date().toISOString(),
+		},
+		resolver: zodResolver(medicationAdministrationSchema),
+	});
+
+	useEffect(() => {
+		const newTimestamp = new Date(
+			`${datePart}T${timePart}:00.000Z`,
+		).toISOString();
+		form.setValue('timestamp', newTimestamp, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+	}, [datePart, timePart, form]);
+
+	useEffect(() => {
+		if (isOpen) {
+			// Reset form when dialog opens or initialData changes
+			const initialTimestamp = initialData?.timestamp
+				? new Date(initialData.timestamp)
+				: new Date();
+			setDatePart(dateToDateInputValue(initialTimestamp));
+			setTimePart(dateToTimeInputValue(initialTimestamp));
+
+			form.reset({
+				administrationStatus: initialData?.administrationStatus || 'On Time',
+				details: initialData?.details || '',
+				dosageAmount: initialData?.dosageAmount || undefined,
+				dosageUnit: initialData?.dosageUnit || '',
+				medicationName: initialData?.medicationName || '',
+				regimenId: initialData?.regimenId || undefined,
+				timestamp: initialTimestamp.toISOString(),
+			});
+		}
+	}, [initialData, form, isOpen]);
+
+	const medicationOptions = useMemo(() => {
+		const options: ComboboxOption[] = [];
+		const seenNames = new Set<string>();
+
+		// Add regimens
+		regimens.forEach((reg) => {
+			const value = `regimen-${reg.id}-${reg.name}`; // Unique value for regimen
+			options.push({
+				dosageAmount: reg.dosageAmount,
+				dosageUnit: reg.dosageUnit,
+				label: reg.name,
+				regimenId: reg.id,
+				type: 'regimen',
+				value,
+			});
+			seenNames.add(reg.name.toLowerCase());
+		});
+
+		// Add unique one-off medication names from past administrations
+		allAdministrations.forEach((admin) => {
+			if (
+				!admin.regimenId &&
+				admin.medicationName &&
+				!seenNames.has(admin.medicationName.toLowerCase())
+			) {
+				options.push({
+					dosageAmount: admin.dosageAmount,
+					dosageUnit: admin.dosageUnit,
+					label: admin.medicationName,
+					type: 'one-off',
+					value: admin.medicationName, // Use name itself as value for one-offs
+				});
+				seenNames.add(admin.medicationName.toLowerCase());
+			}
+		});
+		return options;
+	}, [regimens, allAdministrations]);
+
+	const handleFormSubmit = (data: MedicationAdministrationFormData) => {
+		onSubmit(data, initialData?.id);
+		onClose();
+	};
+
+	if (!isOpen) {
+		return null;
+	}
+
+	return (
+		<Dialog onOpenChange={(open) => !open && onClose()} open={isOpen}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>
+						{initialData ? (
+							<fbt desc="Dialog title for editing a medication entry">
+								Edit Medication Entry
+							</fbt>
+						) : (
+							<fbt desc="Dialog title for adding a new medication entry">
+								Add Medication Entry
+							</fbt>
+						)}
+					</DialogTitle>
+					<DialogDescription>
+						{initialData ? (
+							<fbt desc="Dialog description for editing a medication entry">
+								Update the details of this medication administration.
+							</fbt>
+						) : (
+							<fbt desc="Dialog description for adding a new medication entry">
+								Log a new medication administration.
+							</fbt>
+						)}
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					className="space-y-4 max-h-[70vh] overflow-y-auto p-1 pr-3"
+					onSubmit={form.handleSubmit(handleFormSubmit)}
+				>
+					{/* Medication Name (Combobox) */}
+					<div className="space-y-1">
+						<Label htmlFor="medicationName">
+							<fbt desc="Label for medication name input">Medication Name</fbt>
+						</Label>
+						<Controller
+							control={form.control}
+							name="medicationName"
+							render={({ field }) => (
+								<Popover onOpenChange={setComboboxOpen} open={comboboxOpen}>
+									<PopoverTrigger asChild>
+										<Button
+											aria-expanded={comboboxOpen}
+											className="w-full justify-between"
+											role="combobox"
+											variant="outline"
+										>
+											{field.value ? (
+												medicationOptions.find(
+													(option) =>
+														option.value === field.value ||
+														option.label === field.value,
+												)?.label || field.value
+											) : (
+												<fbt desc="Placeholder text for medication name combobox">
+													Select or type medication...
+												</fbt>
+											)}
+											<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+										</Button>
+									</PopoverTrigger>
+									<PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+										<Command
+											filter={(value, search) => {
+												const option = medicationOptions.find(
+													(opt) => opt.value === value,
+												);
+												if (
+													option?.label
+														.toLowerCase()
+														.includes(search.toLowerCase())
+												)
+													return 1;
+												return 0;
+											}}
+										>
+											<CommandInput
+												placeholder={fbt(
+													'Search medication...',
+													'Placeholder for medication search input in combobox',
+												)}
+											/>
+											<CommandList>
+												<CommandEmpty>
+													<fbt desc="Message shown when no medication is found in combobox search">
+														No medication found.
+													</fbt>
+												</CommandEmpty>
+												<CommandGroup>
+													{medicationOptions.map((option) => (
+														<CommandItem
+															key={option.value}
+															onSelect={(currentValue) => {
+																const selectedOption = medicationOptions.find(
+																	(opt) => opt.value === currentValue,
+																);
+																if (selectedOption) {
+																	form.setValue(
+																		'medicationName',
+																		selectedOption.label,
+																		{ shouldDirty: true, shouldValidate: true },
+																	);
+																	form.setValue(
+																		'dosageAmount',
+																		selectedOption.dosageAmount ?? Number.NaN,
+																		{ shouldDirty: true },
+																	);
+																	form.setValue(
+																		'dosageUnit',
+																		selectedOption.dosageUnit || '',
+																		{ shouldDirty: true },
+																	);
+																	form.setValue(
+																		'regimenId',
+																		selectedOption.regimenId || undefined,
+																		{ shouldDirty: true },
+																	);
+																} else {
+																	// Manual entry
+																	form.setValue(
+																		'medicationName',
+																		currentValue,
+																		{ shouldDirty: true, shouldValidate: true },
+																	); // Use raw input if not found
+																	form.setValue('regimenId', undefined, {
+																		shouldDirty: true,
+																	}); // Clear regimenId for manual entry
+																}
+																setComboboxOpen(false);
+															}}
+															value={option.value}
+														>
+															<Check
+																className={cn(
+																	'mr-2 h-4 w-4',
+																	field.value === option.label ||
+																		field.value === option.value
+																		? 'opacity-100'
+																		: 'opacity-0',
+																)}
+															/>
+															{option.label}{' '}
+															{option.type === 'regimen' && (
+																<span className="text-xs text-muted-foreground ml-2">
+																	(Regimen)
+																</span>
+															)}
+														</CommandItem>
+													))}
+												</CommandGroup>
+											</CommandList>
+										</Command>
+									</PopoverContent>
+								</Popover>
+							)}
+						/>
+						{form.formState.errors.medicationName && (
+							<p className="text-sm text-red-500">
+								{form.formState.errors.medicationName.message}
+							</p>
+						)}
+					</div>
+
+					{/* Dosage Amount & Unit */}
+					<div className="grid grid-cols-2 gap-4">
+						<div className="space-y-1">
+							<Label htmlFor="dosageAmount">
+								<fbt desc="Label for dosage amount input">Dosage Amount</fbt>
+							</Label>
+							<Input
+								id="dosageAmount"
+								step="any"
+								type="number"
+								{...form.register('dosageAmount', { valueAsNumber: true })}
+							/>
+							{form.formState.errors.dosageAmount && (
+								<p className="text-sm text-red-500">
+									{form.formState.errors.dosageAmount.message}
+								</p>
+							)}
+						</div>
+						<div className="space-y-1">
+							<Label htmlFor="dosageUnit">
+								<fbt desc="Label for dosage unit input">Unit</fbt>
+							</Label>
+							<Input
+								id="dosageUnit"
+								{...form.register('dosageUnit')}
+								placeholder={fbt(
+									'e.g., ml, mg, drops',
+									'Placeholder for dosage unit input',
+								)}
+							/>
+							{form.formState.errors.dosageUnit && (
+								<p className="text-sm text-red-500">
+									{form.formState.errors.dosageUnit.message}
+								</p>
+							)}
+						</div>
+					</div>
+
+					{/* Timestamp (Date and Time) */}
+					<div className="grid grid-cols-2 gap-4">
+						<div className="space-y-1">
+							<Label htmlFor="adminDate">
+								<fbt common>
+									Date
+								</fbt>
+							</Label>
+							<Input
+								id="adminDate"
+								onChange={(e) => setDatePart(e.target.value)}
+								type="date"
+								value={datePart}
+							/>
+						</div>
+						<div className="space-y-1">
+							<Label htmlFor="adminTime">
+								<fbt common>
+									Time
+								</fbt>
+							</Label>
+							<Input
+								id="adminTime"
+								onChange={(e) => setTimePart(e.target.value)}
+								type="time"
+								value={timePart}
+							/>
+						</div>
+					</div>
+					{/* Hidden input for react-hook-form to track the combined timestamp */}
+					<input type="hidden" {...form.register('timestamp')} />
+					{form.formState.errors.timestamp && (
+						<p className="text-sm text-red-500">
+							{form.formState.errors.timestamp.message}
+						</p>
+					)}
+
+					{/* Administration Status */}
+					<div className="space-y-1">
+						<Label>
+							<fbt desc="Label for administration status radio group">
+								Administration Status
+							</fbt>
+						</Label>
+						<Controller
+							control={form.control}
+							name="administrationStatus"
+							render={({ field }) => (
+								<RadioGroup
+									className="flex space-x-4 pt-1"
+									onValueChange={field.onChange}
+									value={field.value}
+								>
+									{(['On Time', 'Missed', 'Adjusted'] as const).map(
+										(status) => (
+											<div className="flex items-center space-x-2" key={status}>
+												<RadioGroupItem
+													id={`status-${status}`}
+													value={status}
+												/>
+												<Label htmlFor={`status-${status}`}>{status}</Label>
+											</div>
+										),
+									)}
+								</RadioGroup>
+							)}
+						/>
+						{form.formState.errors.administrationStatus && (
+							<p className="text-sm text-red-500">
+								{form.formState.errors.administrationStatus.message}
+							</p>
+						)}
+					</div>
+
+					{/* Details/Notes */}
+					<div className="space-y-1">
+						<Label htmlFor="details">
+							<fbt desc="Label for optional details/notes textarea">
+								Details/Notes (Optional)
+							</fbt>
+						</Label>
+						<Textarea
+							id="details"
+							{...form.register('details')}
+							placeholder={fbt(
+								'e.g., child spit out some, given with food',
+								'Placeholder for medication administration notes',
+							)}
+						/>
+					</div>
+
+					<DialogFooter>
+						<Button onClick={onClose} type="button" variant="outline">
+							<fbt common>Cancel</fbt>
+						</Button>
+						<Button disabled={form.formState.isSubmitting} type="submit">
+							{initialData ? (
+								<fbt desc="Button text to save changes to an existing medication entry">Save Changes</fbt>
+							) : (
+								<fbt desc="Button text to save a new medication entry">Save Entry</fbt>
+							)}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/src/app/medication/components/medication-administration-item.tsx
+++ b/src/app/medication/components/medication-administration-item.tsx
@@ -1,18 +1,18 @@
 import { format } from 'date-fns';
+// Ensure fbt is imported
 import { Edit, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Medication } from '@/types/medication'; // Assuming Medication type is here
+import { MedicationAdministration } from '@/types/medication'; // Updated type
 
 interface MedicationAdministrationItemProps {
-	getRegimenNameById: (regimenId: string) => string;
-	med: Medication;
+	med: MedicationAdministration;
 	onDeleteAdministration: (adminId: string) => void;
 	onEditAdministration: (adminId: string) => void;
+	// getRegimenNameById is removed as medicationName and dosageUnit are now direct properties
 }
 
 export function MedicationAdministrationItem({
-	getRegimenNameById,
 	med,
 	onDeleteAdministration,
 	onEditAdministration,
@@ -22,7 +22,8 @@ export function MedicationAdministrationItem({
 			<CardContent className="p-3 flex justify-between items-center">
 				<div className="flex-1">
 					<p className="font-medium text-base">
-						{getRegimenNameById(med.regimenId)} - {med.dosageAmount}
+						{med.medicationName} - {med.dosageAmount}
+						{med.dosageUnit}
 					</p>
 					<p className="text-sm text-muted-foreground">
 						{format(new Date(med.timestamp), 'h:mm a')}
@@ -31,6 +32,13 @@ export function MedicationAdministrationItem({
 						{med.administrationStatus}
 						{med.details && ` (${med.details})`}
 					</p>
+					{med.regimenId && (
+						<p className="text-xs text-muted-foreground italic">
+							<fbt desc="Indicator that this administration is linked to a regimen">
+								(Linked to regimen)
+							</fbt>
+						</p>
+					)}
 				</div>
 				<div className="flex gap-1">
 					<Button

--- a/src/app/medication/page.tsx
+++ b/src/app/medication/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { PlusCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import HistoryListInternal from '@/components/history-list';
 import {
@@ -8,42 +9,46 @@ import {
 	AccordionItem,
 	AccordionTrigger,
 } from '@/components/ui/accordion';
-// Card components are now used in sub-components
+import { Button } from '@/components/ui/button';
 import { useMedicationRegimens } from '@/hooks/use-medication-regimens';
 import { useMedications } from '@/hooks/use-medications';
-// Ensure Medication type is imported if not already
+import { MedicationAdministration } from '@/types/medication';
 import { MedicationRegimen } from '@/types/medication-regimen';
-import '@/i18n';
+import { MedicationAdministrationForm } from './components/medication-administration-form';
 import { MedicationAdministrationItem } from './components/medication-administration-item';
 import { RegimenAccordionContent } from './components/regimen-accordion-content';
+import { MedicationAdministrationFormData } from './validation/medication-administration-schema';
+import '@/i18n'; // Ensure i18n is loaded
 
-// calculateNextDue and formatSchedule are now used by sub-components, imported within them from utils.ts
-
-// Placeholder functions for edit/delete actions
+// Placeholder functions for regimen edit/delete actions (if needed for this page)
 const handleEditRegimen = (regimenId: string) => {
+	// console.log('Edit regimen:', regimenId); // Removed console.log
 	/* Placeholder for actual edit logic */
 };
 const handleDeleteRegimen = (regimenId: string) => {
-	/* Placeholder for actual delete logic */
-};
-const handleEditAdministration = (adminId: string) => {
+	// console.log('Delete regimen:', regimenId); // Removed console.log
 	/* Placeholder for actual edit logic */
-};
-const handleDeleteAdministration = (adminId: string) => {
-	/* Placeholder for actual delete logic */
 };
 
 export default function MedicationPage() {
 	const {
-		remove: removeRegimen,
-		update: updateRegimen,
+		// remove: removeRegimen, // Not used directly in this version for regimen deletion
+		// update: updateRegimen, // Not used directly in this version for regimen update
 		value: medicationRegimens,
 	} = useMedicationRegimens();
+
 	const {
+		add: addMedication,
 		remove: removeMedication,
 		update: updateMedication,
 		value: medications,
 	} = useMedications();
+
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [editingAdministration, setEditingAdministration] = useState<
+		MedicationAdministration | undefined
+	>(undefined);
+
 	const [expandedRegimens, setExpandedRegimens] = useState<
 		Record<string, boolean>
 	>({});
@@ -52,9 +57,48 @@ export default function MedicationPage() {
 		setExpandedRegimens((prev) => ({ ...prev, [regimenId]: !prev[regimenId] }));
 	};
 
+	const handleOpenFormForAdd = () => {
+		setEditingAdministration(undefined);
+		setIsFormOpen(true);
+	};
+
+	const handleOpenFormForEdit = (adminId: string) => {
+		const administrationToEdit = (medications || []).find(
+			(med) => med.id === adminId,
+		);
+		if (administrationToEdit) {
+			setEditingAdministration(administrationToEdit);
+			setIsFormOpen(true);
+		}
+	};
+
+	const handleSaveAdministration = (
+		data: MedicationAdministrationFormData,
+		id?: string,
+	) => {
+		if (id) {
+			// Editing existing
+			const existingAdmin = (medications || []).find((med) => med.id === id);
+			if (existingAdmin) {
+				updateMedication({ ...existingAdmin, ...data });
+			}
+		} else {
+			// Adding new
+			const newAdministration: MedicationAdministration = {
+				...data,
+				id: crypto.randomUUID(), // Generate a new ID
+			};
+			addMedication(newAdministration);
+		}
+		setIsFormOpen(false); // Close form after save
+	};
+
+	const handleDeleteAdministration = (adminId: string) => {
+		removeMedication(adminId);
+	};
+
 	const { activeRegimens, pastRegimens } = useMemo(() => {
 		const now = new Date().toISOString();
-		// Ensure medicationRegimens is an array before calling reduce (it should be by hook design)
 		return (medicationRegimens || []).reduce(
 			(acc, regimen) => {
 				const isActive =
@@ -74,10 +118,12 @@ export default function MedicationPage() {
 		);
 	}, [medicationRegimens]);
 
-	const getRegimenNameById = (regimenId: string) => {
-		// Ensure medicationRegimens is an array before calling find
+	// This function will be deprecated for direct display once history list is updated,
+	// but might still be useful for other logic if needed.
+	const getRegimenNameById = (regimenId?: string) => {
+		if (!regimenId) return 'N/A (One-off)';
 		const regimen = (medicationRegimens || []).find((r) => r.id === regimenId);
-		return regimen ? regimen.name : 'Unknown Medication';
+		return regimen ? regimen.name : 'Unknown Regimen';
 	};
 
 	return (
@@ -97,13 +143,13 @@ export default function MedicationPage() {
 						<AccordionContent>
 							<RegimenAccordionContent
 								expandedRegimens={expandedRegimens}
-								handleDeleteRegimen={handleDeleteRegimen}
-								handleEditRegimen={handleEditRegimen}
+								handleDeleteRegimen={handleDeleteRegimen} // Keep if regimen management is on this page
+								handleEditRegimen={handleEditRegimen} // Keep if regimen management is on this page
 								isPastSection={false}
 								noItemsMessage={
 									<p>
 										<fbt desc="Message when there are no active regimens">
-											No active regimens.
+											No active regimens. Add a new regimen to get started.
 										</fbt>
 									</p>
 								}
@@ -121,8 +167,8 @@ export default function MedicationPage() {
 						<AccordionContent>
 							<RegimenAccordionContent
 								expandedRegimens={expandedRegimens}
-								handleDeleteRegimen={handleDeleteRegimen}
-								handleEditRegimen={handleEditRegimen}
+								handleDeleteRegimen={handleDeleteRegimen} // Keep if regimen management is on this page
+								handleEditRegimen={handleEditRegimen} // Keep if regimen management is on this page
 								isPastSection={true}
 								noItemsMessage={
 									<p>
@@ -144,24 +190,39 @@ export default function MedicationPage() {
 					<h2 className="text-xl font-semibold">
 						<fbt desc="Section heading for Medication History">History</fbt>
 					</h2>
-					{/* Placeholder for a potential "Add Administration" button, similar to other pages */}
-					{/* <Button size="sm" variant="outline"><PlusCircle className="h-4 w-4 mr-1" /> <fbt>Add Administration</fbt></Button> */}
+					<Button onClick={handleOpenFormForAdd} size="sm" variant="outline">
+						<PlusCircle className="h-4 w-4 mr-1" />
+						<fbt desc="Button text to add a new medication administration entry">
+							Add Entry
+						</fbt>
+					</Button>
 				</div>
 				<HistoryListInternal
 					dateAccessor={(med) => med.timestamp}
-					entries={medications || []} // Pass medications directly, ensure it's an array
+					entries={medications || []}
 				>
 					{(med) => (
 						<MedicationAdministrationItem
-							getRegimenNameById={getRegimenNameById}
+							// getRegimenNameById prop removed
 							key={med.id}
 							med={med}
 							onDeleteAdministration={handleDeleteAdministration}
-							onEditAdministration={handleEditAdministration}
+							onEditAdministration={handleOpenFormForEdit}
 						/>
 					)}
 				</HistoryListInternal>
 			</section>
+
+			{isFormOpen && (
+				<MedicationAdministrationForm
+					allAdministrations={medications || []}
+					initialData={editingAdministration}
+					isOpen={isFormOpen}
+					onClose={() => setIsFormOpen(false)}
+					onSubmit={handleSaveAdministration}
+					regimens={medicationRegimens || []}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/app/medication/validation/medication-administration-schema.ts
+++ b/src/app/medication/validation/medication-administration-schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const medicationAdministrationSchema = z.object({
+	administrationStatus: z.enum(['On Time', 'Missed', 'Adjusted'], {
+		required_error: 'Administration status is required.',
+	}),
+	details: z.string().optional(),
+	dosageAmount: z
+		.number({ invalid_type_error: 'Dosage amount must be a number.' })
+		.positive({ message: 'Dosage amount must be positive.' }),
+	dosageUnit: z.string().min(1, { message: 'Dosage unit is required.' }),
+	medicationName: z
+		.string()
+		.min(1, { message: 'Medication name is required.' }),
+	regimenId: z.string().optional(),
+	timestamp: z
+		.string()
+		.datetime({ message: 'Invalid date and time format.' })
+		.min(1, { message: 'Timestamp is required.' }),
+	// id is not part of the form validation for creation, it's generated
+});
+
+export type MedicationAdministrationFormData = z.infer<
+	typeof medicationAdministrationSchema
+>;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+import * as React from 'react';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+function Command({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+	return (
+		<CommandPrimitive
+			data-slot="command"
+			className={cn(
+				'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CommandDialog({
+	title = 'Command Palette',
+	description = 'Search for a command to run...',
+	children,
+	className,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof Dialog> & {
+	title?: string;
+	description?: string;
+	className?: string;
+	showCloseButton?: boolean;
+}) {
+	return (
+		<Dialog {...props}>
+			<DialogHeader className="sr-only">
+				<DialogTitle>{title}</DialogTitle>
+				<DialogDescription>{description}</DialogDescription>
+			</DialogHeader>
+			<DialogContent
+				className={cn('overflow-hidden p-0', className)}
+				showCloseButton={showCloseButton}
+			>
+				<Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+					{children}
+				</Command>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function CommandInput({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+	return (
+		<div
+			data-slot="command-input-wrapper"
+			className="flex h-9 items-center gap-2 border-b px-3"
+		>
+			<SearchIcon className="size-4 shrink-0 opacity-50" />
+			<CommandPrimitive.Input
+				data-slot="command-input"
+				className={cn(
+					'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+					className,
+				)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function CommandList({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+	return (
+		<CommandPrimitive.List
+			data-slot="command-list"
+			className={cn(
+				'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CommandEmpty({
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+	return (
+		<CommandPrimitive.Empty
+			data-slot="command-empty"
+			className="py-6 text-center text-sm"
+			{...props}
+		/>
+	);
+}
+
+function CommandGroup({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+	return (
+		<CommandPrimitive.Group
+			data-slot="command-group"
+			className={cn(
+				'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CommandSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+	return (
+		<CommandPrimitive.Separator
+			data-slot="command-separator"
+			className={cn('bg-border -mx-1 h-px', className)}
+			{...props}
+		/>
+	);
+}
+
+function CommandItem({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+	return (
+		<CommandPrimitive.Item
+			data-slot="command-item"
+			className={cn(
+				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CommandShortcut({
+	className,
+	...props
+}: React.ComponentProps<'span'>) {
+	return (
+		<span
+			data-slot="command-shortcut"
+			className={cn(
+				'text-muted-foreground ml-auto text-xs tracking-widest',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Command,
+	CommandDialog,
+	CommandInput,
+	CommandList,
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandShortcut,
+	CommandSeparator,
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Popover({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = 'center',
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+					className,
+				)}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+function PopoverAnchor({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/src/data/medication-regimens.ts
+++ b/src/data/medication-regimens.ts
@@ -3,7 +3,7 @@ import { proxy } from 'valtio';
 import { MedicationRegimen } from '@/types/medication-regimen';
 import { Encrypted } from '@/utils/crypto'; // Import Encrypted
 
-// Initialize with an empty array, as default data is now handled by the hook.
+// Initialize with an empty EncryptedArray object, as default data is now handled by the hook.
 // The type is Encrypted<MedicationRegimen[]> because useEncryptedArrayState expects
-// its initial array argument `array: Encrypted<T[]>`
-export const medicationRegimensProxy = proxy<Encrypted<MedicationRegimen[]>>([]);
+// this shape.
+export const medicationRegimensProxy = proxy<Encrypted<MedicationRegimen[]>>({ __type: 'array' });

--- a/src/data/medications.ts
+++ b/src/data/medications.ts
@@ -1,9 +1,9 @@
 // src/data/medications.ts
 import { proxy } from 'valtio';
-import { Medication } from '@/types/medication';
+import { MedicationAdministration } from '@/types/medication'; // Updated import
 import { Encrypted } from '@/utils/crypto'; // Import Encrypted
 
-// Initialize with an empty array, as default data is now handled by the hook.
-// The type is Encrypted<Medication[]> because useEncryptedArrayState expects
-// its initial array argument `array: Encrypted<T[]>`
-export const medicationsProxy = proxy<Encrypted<Medication[]>>([]);
+// Initialize with an empty EncryptedArray object, as default data is now handled by the hook.
+// The type is Encrypted<MedicationAdministration[]> because useEncryptedArrayState expects
+// this shape.
+export const medicationsProxy = proxy<Encrypted<MedicationAdministration[]>>({ __type: 'array' });

--- a/src/hooks/use-medications.ts
+++ b/src/hooks/use-medications.ts
@@ -1,29 +1,36 @@
 import { useEffect } from 'react';
-import { medicationsProxy } from '@/data/medications'; // Will be changed in a later step
+import { medicationsProxy } from '@/data/medications';
+import { MedicationAdministration } from '@/types/medication'; // Updated import
 import { useEncryptedArrayState } from './use-encrypted-array-state';
-import { Medication } from '@/types/medication';
 import { useEncryptionKey } from './use-encryption-key';
 
-// Default data for medications
-const defaultMedications: Medication[] = [
+// Default data for medication administrations
+// Values for medicationName and dosageUnit are copied from defaultMedicationRegimens in use-medication-regimens.ts
+const defaultMedications: MedicationAdministration[] = [
 	{
 		administrationStatus: 'On Time',
 		dosageAmount: 0.5,
+		dosageUnit: 'ml', // Copied from regimen-vitamind
 		id: 'med-admin-1',
+		medicationName: 'Vitamin D drops', // Copied from regimen-vitamind
 		regimenId: 'regimen-vitamind',
 		timestamp: '2025-07-01T09:05:00.000Z',
 	},
 	{
 		administrationStatus: 'On Time',
 		dosageAmount: 0.5,
+		dosageUnit: 'ml', // Copied from regimen-vitamind
 		id: 'med-admin-2',
+		medicationName: 'Vitamin D drops', // Copied from regimen-vitamind
 		regimenId: 'regimen-vitamind',
 		timestamp: '2025-07-02T09:03:00.000Z',
 	},
 	{
 		administrationStatus: 'On Time',
 		dosageAmount: 250,
+		dosageUnit: 'mg', // Copied from regimen-antibiotic
 		id: 'med-admin-3',
+		medicationName: 'Amoxicillin', // Copied from regimen-antibiotic
 		regimenId: 'regimen-antibiotic',
 		timestamp: '2025-07-01T08:15:00.000Z',
 	},
@@ -31,7 +38,9 @@ const defaultMedications: Medication[] = [
 		administrationStatus: 'Adjusted',
 		details: 'Given 30 min late due to nap',
 		dosageAmount: 250,
+		dosageUnit: 'mg', // Copied from regimen-antibiotic
 		id: 'med-admin-4',
+		medicationName: 'Amoxicillin', // Copied from regimen-antibiotic
 		regimenId: 'regimen-antibiotic',
 		timestamp: '2025-07-01T16:30:00.000Z',
 	},
@@ -39,14 +48,18 @@ const defaultMedications: Medication[] = [
 		administrationStatus: 'On Time',
 		details: 'Fever 39.2C',
 		dosageAmount: 2.5,
+		dosageUnit: 'ml', // Copied from regimen-feverreducer
 		id: 'med-admin-5',
+		medicationName: 'Paracetamol Syrup', // Copied from regimen-feverreducer
 		regimenId: 'regimen-feverreducer',
 		timestamp: '2025-07-01T21:00:00.000Z',
 	},
 	{
 		administrationStatus: 'On Time',
 		dosageAmount: 0.5,
+		dosageUnit: 'ml', // Copied from regimen-vitamind
 		id: 'med-admin-6',
+		medicationName: 'Vitamin D drops', // Copied from regimen-vitamind
 		regimenId: 'regimen-vitamind',
 		timestamp: '2025-06-30T09:00:00.000Z',
 	},
@@ -54,22 +67,26 @@ const defaultMedications: Medication[] = [
 		administrationStatus: 'Missed',
 		details: 'Forgot overnight dose',
 		dosageAmount: 250,
+		dosageUnit: 'mg', // Copied from regimen-antibiotic
 		id: 'med-admin-7',
+		medicationName: 'Amoxicillin', // Copied from regimen-antibiotic
 		regimenId: 'regimen-antibiotic',
 		timestamp: '2025-06-30T00:00:00.000Z',
 	},
 	{
 		administrationStatus: 'On Time',
 		dosageAmount: 10,
+		dosageUnit: 'mg', // Copied from regimen-old-iron
 		id: 'med-admin-8',
+		medicationName: 'Iron Supplement', // Copied from regimen-old-iron
 		regimenId: 'regimen-old-iron',
 		timestamp: '2025-05-29T17:00:00.000Z',
 	},
 ];
 
 export const useMedications = () => {
-	const state = useEncryptedArrayState<Medication>(
-		medicationsProxy, // This will be changed to an empty array proxy in a later step
+	const state = useEncryptedArrayState<MedicationAdministration>( // Updated type
+		medicationsProxy,
 		'medications-backup',
 	);
 	const secret = useEncryptionKey();
@@ -77,11 +94,16 @@ export const useMedications = () => {
 	useEffect(() => {
 		// Only set default data if the current value is empty, secret is available,
 		// and default data actually has items.
-		if (state.value && state.value.length === 0 && secret && defaultMedications.length > 0) {
+		if (
+			state.value &&
+			state.value.length === 0 &&
+			secret &&
+			defaultMedications.length > 0
+		) {
 			state.replace(defaultMedications);
 		}
 		// defaultMedications is a module-level const and doesn't need to be in the dependency array.
-	}, [state.value, state.replace, secret]);
+	}, [state, secret]); // Added state to dependency array, state.value and state.replace are part of state.
 
 	return state;
 };

--- a/src/types/medication.ts
+++ b/src/types/medication.ts
@@ -2,26 +2,31 @@
 
 /**
  * Represents a single instance of medication administered to the child.
- * This entry typically logs an administration that is part of a MedicationRegimen.
+ * This can be linked to a MedicationRegimen or be a one-off administration.
  */
-export interface Medication {
+export interface MedicationAdministration {
 	/**
 	 * Indicates if this administration was given as planned ('On Time'),
 	 * if it was missed ('Missed'), or given at a different time/dosage ('Adjusted').
+	 * For one-off administrations, 'On Time' would typically be used.
 	 */
 	administrationStatus: 'On Time' | 'Missed' | 'Adjusted';
 
 	/**
 	 * Optional: Specific notes for this particular administration (e.g., "Child spit out half", "Given late").
-	 * This is separate from the general notes on the regimen.
 	 */
 	details?: string;
 
 	/**
 	 * The actual dosage amount given for this specific administration.
-	 * This might differ from the regimen's planned dosage (e.g., if a partial dose was given).
 	 */
 	dosageAmount: number;
+
+	/**
+	 * The unit for the dosageAmount (e.g., "ml", "mg", "drops").
+	 * If linked to a regimen, this is copied from the regimen at the time of administration.
+	 */
+	dosageUnit: string;
 
 	/**
 	 * Unique identifier for this individual medication administration.
@@ -29,10 +34,16 @@ export interface Medication {
 	id: string;
 
 	/**
-	 * The ID of the MedicationRegimen this administration belongs to.
-	 * This links the individual log to its broader plan and allows inheriting properties like dosage unit.
+	 * The name of the medication administered.
+	 * If linked to a regimen, this is copied from the regimen at the time of administration.
 	 */
-	regimenId: string;
+	medicationName: string;
+
+	/**
+	 * Optional: The ID of the MedicationRegimen this administration belongs to.
+	 * If undefined, this administration is a one-off event not tied to a specific regimen.
+	 */
+	regimenId?: string;
 
 	/**
 	 * The exact date and time the medication was given, in ISO 8601 string format.


### PR DESCRIPTION
- Decoupled MedicationAdministration type from MedicationRegimen:
  - Made regimenId optional.
  - Added medicationName, dosageAmount, dosageUnit directly to MedicationAdministration.
- Updated default medication data to conform to the new type structure.
- Created a new Medication Administration form (modal dialog) using shadcn/ui components (Dialog, Command for Combobox, Popover, RadioGroup, etc.) and react-hook-form.
- Implemented form fields:
  - Medication Name with autocomplete (Combobox) sourcing from regimens and previous one-off administrations, with auto-fill for dosage/unit.
  - Dosage Amount and Unit inputs.
  - Timestamp input (date and time pickers).
  - Administration Status input.
  - Optional Details/Notes input.
- Implemented Zod validation for the new form.
- Added data handling for creating new and editing existing administration records.
- Updated medication history display to use direct properties from MedicationAdministration records.
- Added "Add Entry" button to the Medications page.
- Installed necessary dependencies: react-hook-form, @hookform/resolvers, zod.
- Ensured UI consistency and addressed i18n for new strings.