### PR TITLE
feat: Integrate Autocomplete into Medication Form with Frecency

### DIFF
--- a/src/app/medication/types/medication-autocomplete-option.ts
+++ b/src/app/medication/types/medication-autocomplete-option.ts
@@ -1,0 +1,11 @@
+// src/app/medication/types/medication-autocomplete-option.ts
+
+export interface MedicationAutocompleteOptionData {
+	dosageAmount: number;
+	dosageUnit: string;
+	id: string; // Unique identifier for the option (e.g., "medicationName-dosageAmount-dosageUnit" or "regimen-id")
+	isRegimen?: boolean; // To differentiate regimen options for rendering or logic
+	label: string; // Text to be displayed and filtered against (typically medicationName)
+	medicationName: string;
+	regimenId?: string; // Optional, if the suggestion comes from a regimen
+}

--- a/src/app/medication/utils/frecency-calculator.test.ts
+++ b/src/app/medication/utils/frecency-calculator.test.ts
@@ -1,0 +1,207 @@
+// src/app/medication/utils/frecency-calculator.test.ts
+
+import { describe, expect, it } from 'vitest'; // Added this line
+import { MedicationAdministration } from '@/types/medication';
+import { calculateFrecencySuggestions } from './frecency-calculator';
+
+const baseTime = new Date(2024, 0, 10, 12, 0, 0).getTime(); // Jan 10, 2024, 12:00:00
+
+const administrations: MedicationAdministration[] = [
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 200,
+		dosageUnit: 'mg',
+		id: '1',
+		medicationName: 'Paracetamol',
+		timestamp: new Date(baseTime - 1000 * 60 * 60 * 2).toISOString(), // 2 hours ago
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 400,
+		dosageUnit: 'mg',
+		id: '2',
+		medicationName: 'Ibuprofen',
+		timestamp: new Date(baseTime - 1000 * 60 * 60 * 1).toISOString(), // 1 hour ago
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 200,
+		dosageUnit: 'mg',
+		id: '3',
+		medicationName: 'Paracetamol',
+		regimenId: 'reg-para-200',
+		timestamp: new Date(baseTime).toISOString(), // Now
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 250,
+		dosageUnit: 'ml',
+		id: '4',
+		medicationName: 'Amoxicillin',
+		timestamp: new Date(baseTime - 1000 * 60 * 30).toISOString(), // 30 mins ago
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 500, // Different dosage
+		dosageUnit: 'mg',
+		id: '5',
+		medicationName: 'Paracetamol',
+		timestamp: new Date(baseTime - 1000 * 60 * 5).toISOString(), // 5 mins ago
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 400,
+		dosageUnit: 'mg',
+		id: '6',
+		medicationName: 'Ibuprofen', // Same as #2
+		timestamp: new Date(baseTime - 1000 * 60 * 60 * 3).toISOString(), // 3 hours ago (older)
+	},
+	{
+		administrationStatus: 'On Time',
+		dosageAmount: 200,
+		dosageUnit: 'MG', // Case-insensitivity check for unit
+		id: '7',
+		medicationName: 'paracetamol', // Case-insensitivity check for name
+		timestamp: new Date(baseTime - 1000 * 60 * 10).toISOString(), // 10 mins ago
+	},
+];
+
+describe('calculateFrecencySuggestions', () => {
+	it('should return an empty array for no administrations', () => {
+		expect(calculateFrecencySuggestions([])).toEqual([]);
+	});
+
+	it('should correctly calculate frecency and sort suggestions', () => {
+		const suggestions = calculateFrecencySuggestions(administrations);
+
+		// Expected order:
+		// 1. Paracetamol 200mg (count 3, latest 'now' via ID 3, then ID 7 10 mins ago, then ID 1 2 hours ago)
+		// 2. Ibuprofen 400mg (count 2, latest '1 hour ago' via ID 2, then ID 6 3 hours ago)
+		// 3. Paracetamol 500mg (count 1, latest '5 mins ago' via ID 5)
+		// 4. Amoxicillin 250ml (count 1, latest '30 mins ago' via ID 4)
+
+		expect(suggestions).toHaveLength(4);
+
+		// Check Paracetamol 200mg (should be first due to highest count)
+		expect(suggestions[0]).toMatchObject({
+			dosageAmount: 200,
+			dosageUnit: 'mg', // from ID 3 or 7
+			id: 'paracetamol-200-mg',
+			isRegimen: false,
+			label: 'Paracetamol', // or 'paracetamol' depending on first entry, map key normalizes
+			medicationName: 'Paracetamol', // from ID 3 or 7 (most recent of this combo)
+			regimenId: 'reg-para-200', // From ID 3, the most recent Paracetamol 200mg
+		});
+
+		// Check Ibuprofen 400mg (second due to count 2)
+		expect(suggestions[1]).toMatchObject({
+			dosageAmount: 400,
+			dosageUnit: 'mg',
+			id: 'ibuprofen-400-mg',
+			isRegimen: false,
+			label: 'Ibuprofen',
+			medicationName: 'Ibuprofen',
+			// regimenId should be undefined as neither source had one
+		});
+		expect(suggestions[1].regimenId).toBeUndefined();
+
+		// Check Paracetamol 500mg (count 1, more recent than Amoxicillin)
+		expect(suggestions[2]).toMatchObject({
+			dosageAmount: 500,
+			dosageUnit: 'mg',
+			id: 'paracetamol-500-mg',
+			isRegimen: false,
+			label: 'Paracetamol',
+			medicationName: 'Paracetamol',
+		});
+
+		// Check Amoxicillin 250ml (count 1, older than Paracetamol 500mg)
+		expect(suggestions[3]).toMatchObject({
+			dosageAmount: 250,
+			dosageUnit: 'ml',
+			id: 'amoxicillin-250-ml',
+			isRegimen: false,
+			label: 'Amoxicillin',
+			medicationName: 'Amoxicillin',
+		});
+	});
+
+	it('should handle entries with missing dosageAmount or dosageUnit gracefully by skipping them', () => {
+		const incompleteAdministrations: MedicationAdministration[] = [
+			{
+				id: '1',
+				medicationName: 'TestMed',
+				// @ts-expect-error Testing invalid data
+				administrationStatus: 'On Time',
+				dosageAmount: undefined,
+				dosageUnit: 'mg',
+				timestamp: new Date().toISOString(),
+			},
+			{
+				dosageAmount: 100,
+				id: '2',
+				medicationName: 'AnotherMed',
+				// @ts-expect-error Testing invalid data
+				administrationStatus: 'On Time',
+				dosageUnit: null,
+				timestamp: new Date().toISOString(),
+			},
+			{
+				administrationStatus: 'On Time',
+				dosageAmount: 50,
+				dosageUnit: 'ml',
+				id: '3',
+				medicationName: 'ValidMed',
+				timestamp: new Date().toISOString(),
+			},
+		];
+		// @ts-expect-error Testing robustness against malformed data
+		const suggestions = calculateFrecencySuggestions(incompleteAdministrations);
+		expect(suggestions).toHaveLength(1);
+		expect(suggestions[0].medicationName).toBe('ValidMed');
+	});
+
+	it('should be case-insensitive for medication name and unit for grouping', () => {
+		const caseTestAdmin: MedicationAdministration[] = [
+			{
+				administrationStatus: 'On Time',
+				dosageAmount: 10,
+				dosageUnit: 'ml',
+				id: 'a1',
+				medicationName: 'MedX',
+				timestamp: new Date(baseTime).toISOString(),
+			},
+			{
+				administrationStatus: 'On Time',
+				dosageAmount: 10,
+				dosageUnit: 'ML', // Uppercase unit
+				id: 'a2',
+				medicationName: 'medx', // Lowercase name
+				timestamp: new Date(baseTime + 1000).toISOString(), // More recent
+			},
+			{
+				administrationStatus: 'On Time',
+				dosageAmount: 10,
+				dosageUnit: 'ml',
+				id: 'a3',
+				medicationName: 'MedY',
+				timestamp: new Date(baseTime + 2000).toISOString(),
+			},
+		];
+		const suggestions = calculateFrecencySuggestions(caseTestAdmin);
+		expect(suggestions).toHaveLength(2); // MedX and MedY
+
+		// MedX should have count 2, and its details from the most recent one ('a2')
+		const medXSuggestion = suggestions.find((s) => s.id === 'medx-10-ml');
+		expect(medXSuggestion).toBeDefined();
+		// The medicationName and dosageUnit should be from one of the entries,
+		// the frecencyMap stores the first encountered casing for name/unit, then updates timestamp/count.
+		// Let's ensure the original casing of the most recent item for these fields is preferred if possible,
+		// or at least consistent. The current implementation stores the first encountered.
+		// For the test, we'll accept that the `id` is normalized.
+		// The `label`, `medicationName`, `dosageUnit` will be from the first entry that created the key.
+		// The test data is set up such that 'MedX' and 'ml' are first.
+		expect(medXSuggestion?.medicationName).toBe('MedX'); // From 'a1'
+		expect(medXSuggestion?.dosageUnit).toBe('ml'); // From 'a1'
+	});
+});

--- a/src/app/medication/utils/frecency-calculator.ts
+++ b/src/app/medication/utils/frecency-calculator.ts
@@ -1,0 +1,94 @@
+// src/app/medication/utils/frecency-calculator.ts
+
+import { MedicationAdministration } from '@/types/medication';
+import { MedicationAutocompleteOptionData } from '../types/medication-autocomplete-option';
+
+interface FrecencyEntry {
+	count: number;
+	dosageAmount: number;
+	dosageUnit: string;
+	lastTimestamp: string;
+	medicationName: string;
+	regimenId?: string; // Keep track if the original source was a regimen entry
+}
+
+export function calculateFrecencySuggestions(
+	allAdministrations: readonly MedicationAdministration[],
+): MedicationAutocompleteOptionData[] {
+	const frecencyMap = new Map<string, FrecencyEntry>();
+
+	allAdministrations.forEach((admin) => {
+		// Ensure dosageAmount and dosageUnit are present, as they are mandatory.
+		// medicationName is also mandatory.
+		if (
+			typeof admin.dosageAmount !== 'number' ||
+			!admin.dosageUnit ||
+			!admin.medicationName
+		) {
+			// This case should ideally not happen if data conforms to MedicationAdministration type
+			return;
+		}
+
+		const key = `${admin.medicationName.toLowerCase()}-${admin.dosageAmount}-${admin.dosageUnit.toLowerCase()}`;
+
+		const existingEntry = frecencyMap.get(key);
+
+		if (existingEntry) {
+			existingEntry.count += 1;
+			if (new Date(admin.timestamp) > new Date(existingEntry.lastTimestamp)) {
+				existingEntry.lastTimestamp = admin.timestamp;
+				// If this instance is linked to a regimen, and the previous wasn't, or if this is more recent,
+				// prefer regimenId from the most recent entry if it helps in tie-breaking or data consistency.
+				// However, a single frecency entry represents a unique med-dose-unit, not a specific regimen instance.
+				// So, we primarily care about the regimenId if ALL instances of this combo came from the SAME regimen.
+				// For simplicity, we'll just update if the current one has a regimenId and is more recent.
+				// This regimenId is more for informational purposes if we want to link back.
+				if (admin.regimenId) {
+					existingEntry.regimenId = admin.regimenId;
+				}
+			}
+		} else {
+			frecencyMap.set(key, {
+				count: 1,
+				dosageAmount: admin.dosageAmount,
+				dosageUnit: admin.dosageUnit,
+				lastTimestamp: admin.timestamp,
+				medicationName: admin.medicationName,
+				regimenId: admin.regimenId,
+			});
+		}
+	});
+
+	const suggestions: MedicationAutocompleteOptionData[] = Array.from(
+		frecencyMap.values(),
+	).map((entry) => ({
+		dosageAmount: entry.dosageAmount,
+		dosageUnit: entry.dosageUnit,
+		id: `${entry.medicationName.toLowerCase()}-${entry.dosageAmount}-${entry.dosageUnit.toLowerCase()}`,
+		isRegimen: false, // These are derived from administrations, so mark as not regimen *template*
+		label: entry.medicationName, // Autocomplete will filter based on this
+		medicationName: entry.medicationName,
+		regimenId: entry.regimenId, // This will be the regimenId of the latest occurrence of this combo
+		// We can store count and lastTimestamp if needed for debugging or more complex UI
+		// count: entry.count,
+		// lastTimestamp: entry.lastTimestamp,
+	}));
+
+	// Sort by frecency: higher count first, then more recent timestamp for ties
+	suggestions.sort((a, b) => {
+		// Need to access count and lastTimestamp, so we'll look them up from the map or add them to suggestions
+		const entryA = frecencyMap.get(a.id)!;
+		const entryB = frecencyMap.get(b.id)!;
+
+		if (entryA.count !== entryB.count) {
+			return entryB.count - entryA.count; // Higher count first
+		}
+		// If counts are equal, sort by recency (more recent first)
+		return (
+			new Date(entryB.lastTimestamp).getTime() -
+			new Date(entryA.lastTimestamp).getTime()
+		);
+	});
+
+	return suggestions;
+}


### PR DESCRIPTION
- Integrates the generic Autocomplete component into the MedicationAdministrationForm.
- Implements frecency-based suggestion logic for medication name, dosage, and unit combinations from past administrations.
- Regimen suggestions are prioritized and listed first.
- Custom renderOption displays medication name prominently with dosage/unit details.
- onOptionSelect auto-fills dosage, unit, and regimenId.
- Ensures data flow and validation with react-hook-form and Zod.
- Adds unit tests for the new frecency calculation utility.