### PR TITLE
Fix: Render modal stories in iframes for better Docs view

### DIFF
--- a/src/app/diaper/components/diaper-form.stories.tsx
+++ b/src/app/diaper/components/diaper-form.stories.tsx
@@ -25,6 +25,11 @@ const meta: Meta<typeof DiaperForm> = {
 	component: DiaperForm,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Diaper/DiaperForm',

--- a/src/app/events/components/event-form.stories.tsx
+++ b/src/app/events/components/event-form.stories.tsx
@@ -31,6 +31,11 @@ const meta: Meta<typeof EventForm> = {
 	component: EventForm,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Events/EventForm',

--- a/src/app/feeding/components/feeding-form.stories.tsx
+++ b/src/app/feeding/components/feeding-form.stories.tsx
@@ -20,6 +20,11 @@ const meta: Meta<typeof FeedingForm> = {
 	component: FeedingForm,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Feeding/FeedingForm',

--- a/src/app/feeding/components/feeding-tracker.stories.tsx
+++ b/src/app/feeding/components/feeding-tracker.stories.tsx
@@ -39,6 +39,11 @@ const meta: Meta<typeof BreastfeedingTracker> = {
 	],
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Feeding/BreastfeedingTracker',

--- a/src/app/growth/components/growth-form.stories.tsx
+++ b/src/app/growth/components/growth-form.stories.tsx
@@ -18,6 +18,11 @@ const meta: Meta<typeof MeasurementForm> = {
 	component: MeasurementForm,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Growth/MeasurementForm',

--- a/src/app/medication/components/medication-administration-form.stories.tsx
+++ b/src/app/medication/components/medication-administration-form.stories.tsx
@@ -78,6 +78,11 @@ const meta: Meta<typeof MedicationAdministrationForm> = {
 	],
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'App/Medication/MedicationAdministrationForm',

--- a/src/components/delete-entry-dialog.stories.tsx
+++ b/src/components/delete-entry-dialog.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof DeleteEntryDialog> = {
 	component: DeleteEntryDialog,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			story: {
+				inline: false,
+			},
+		},
 	},
 	tags: ['autodocs'],
 	title: 'Components/DeleteEntryDialog',


### PR DESCRIPTION
Modal components in Storybook Docs view were overlaying the entire page, making interaction with the Storybook UI impossible.

This change updates relevant stories that feature modals (Dialogs) to set `parameters.docs.story.inline = false;`. This forces these stories to be rendered within an iframe in the Docs tab, isolating their overlay behavior and keeping the main Storybook UI accessible.

Affected stories:
- DeleteEntryDialog
- DiaperForm
- EventForm
- FeedingForm
- FeedingTracker (for manual entry dialog)
- GrowthForm
- MedicationAdministrationForm