### PR TITLE
Fix: Set Storybook iframe height to 100vh for modal previews

### DIFF
--- a/src/app/diaper/components/diaper-form.stories.tsx
+++ b/src/app/diaper/components/diaper-form.stories.tsx
@@ -24,12 +24,13 @@ const meta: Meta<typeof DiaperForm> = {
 	},
 	component: DiaperForm,
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Diaper/DiaperForm',

--- a/src/app/diaper/components/diaper-tracker.stories.tsx
+++ b/src/app/diaper/components/diaper-tracker.stories.tsx
@@ -42,6 +42,12 @@ const meta: Meta<typeof DiaperTracker> = {
 		},
 	],
 	parameters: {
+		docs: {
+			story: {
+				height: '100vh',
+				inline: false, // Explicitly set for clarity, though default for docs
+			},
+		},
 		layout: 'centered',
 	},
 	tags: ['autodocs'],

--- a/src/app/events/components/event-form.stories.tsx
+++ b/src/app/events/components/event-form.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { waitFor, within } from '@testing-library/react';
+import { within } from '@testing-library/react';
 // import { action } from '@storybook/addon-actions'; // Removed
 import userEvent from '@testing-library/user-event';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
@@ -30,12 +30,13 @@ const meta: Meta<typeof EventForm> = {
 	},
 	component: EventForm,
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Events/EventForm',

--- a/src/app/events/components/events-list.stories.tsx
+++ b/src/app/events/components/events-list.stories.tsx
@@ -71,6 +71,12 @@ const meta: Meta<typeof EventsList> = {
 		},
 	],
 	parameters: {
+		docs: {
+			story: {
+				height: '100vh',
+				inline: false, // Explicitly set for clarity
+			},
+		},
 		layout: 'padded',
 	},
 	tags: ['autodocs'],

--- a/src/app/feeding/components/feeding-form.stories.tsx
+++ b/src/app/feeding/components/feeding-form.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { waitFor, within } from '@testing-library/react';
+import { within } from '@testing-library/react';
 // import { action } from '@storybook/addon-actions'; // Removed
 import userEvent from '@testing-library/user-event';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
@@ -19,12 +19,13 @@ const meta: Meta<typeof FeedingForm> = {
 	},
 	component: FeedingForm,
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Feeding/FeedingForm',

--- a/src/app/feeding/components/feeding-tracker.stories.tsx
+++ b/src/app/feeding/components/feeding-tracker.stories.tsx
@@ -38,12 +38,13 @@ const meta: Meta<typeof BreastfeedingTracker> = {
 		},
 	],
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Feeding/BreastfeedingTracker',

--- a/src/app/growth/components/growth-form.stories.tsx
+++ b/src/app/growth/components/growth-form.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { waitFor, within } from '@testing-library/react';
+import { within } from '@testing-library/react';
 // import { action } from '@storybook/addon-actions'; // Removed
 import userEvent from '@testing-library/user-event';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
@@ -17,12 +17,13 @@ const meta: Meta<typeof MeasurementForm> = {
 	},
 	component: MeasurementForm,
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Growth/MeasurementForm',

--- a/src/app/medication/components/medication-administration-form.stories.tsx
+++ b/src/app/medication/components/medication-administration-form.stories.tsx
@@ -71,18 +71,15 @@ const meta: Meta<typeof MedicationAdministrationForm> = {
 		regimens: { control: 'object' },
 	},
 	component: MedicationAdministrationForm,
-	decorators: [
-		(Story, { args }) => (
-			args.isOpen ? <Story /> : null
-		),
-	],
+	decorators: [(Story, { args }) => (args.isOpen ? <Story /> : null)],
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'App/Medication/MedicationAdministrationForm',

--- a/src/components/delete-entry-dialog.stories.tsx
+++ b/src/components/delete-entry-dialog.stories.tsx
@@ -10,12 +10,13 @@ const meta: Meta<typeof DeleteEntryDialog> = {
 	},
 	component: DeleteEntryDialog,
 	parameters: {
-		layout: 'centered',
 		docs: {
 			story: {
+				height: '100vh',
 				inline: false,
 			},
 		},
+		layout: 'centered',
 	},
 	tags: ['autodocs'],
 	title: 'Components/DeleteEntryDialog',


### PR DESCRIPTION
Adjusts specified Storybook stories to have their preview iframes take up the full viewport height (100vh). This is to ensure that modals displayed within these stories are fully visible and testable without being cut off by a shorter iframe.

The `parameters.docs.story.height` property was set to '100vh' for stories identified as displaying modals and being rendered with `inline: false` (the default for docs view).

This addresses the issue where modal previews were not adequately sized.