### PR TITLE
Configure Renovate to group fbtee dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
 	},
 	"packageRules": [
 		{
+			"matchPackageNames": ["fbtee", "@nkzw/babel-preset-fbtee", "@nkzw/eslint-plugin-fbtee"],
+			"groupName": "fbtee-monorepo"
+		},
+		{
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
 		}


### PR DESCRIPTION
This change groups the following packages in Renovate:
- fbtee
- @nkzw/babel-preset-fbtee
- @nkzw/eslint-plugin-fbtee

This will ensure that updates to these packages are handled in a single PR.