### PR TITLE
feat: Add Vercel preview deployment for Storybook

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -23,7 +23,7 @@ jobs:
           version: 10
           run_install: false
 
-      - name: Install Node.js
+      - name: Install Node.js for build
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -39,21 +39,57 @@ jobs:
         run: pnpm run build-storybook
 
       - name: Upload Storybook artifact
-        uses: actions/upload-pages-artifact@v3 # This action is designed for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: storybook-static
+          path: storybook-static # The contents of this directory are uploaded
 
   deploy-to-gh-pages:
     needs: build-storybook
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }} # Output the deployment URL
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 # This action handles downloading the artifact and deploying
-        # No need to explicitly download artifact, actions/deploy-pages handles it by default
-        # No need to specify branch or folder, it uses the artifact from upload-pages-artifact
-        # and deploys to gh-pages branch by default.
-        # Ensure your repository settings are configured to deploy from the gh-pages branch.
+        uses: actions/deploy-pages@v4
+
+  deploy-to-vercel-preview:
+    runs-on: ubuntu-latest
+    needs: build-storybook
+    environment:
+      name: vercel-preview
+      url: ${{ steps.vercel-deployment.outputs.url }} # Vercel CLI 'deploy' outputs 'url'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages # Artifact from 'build-storybook' job
+          path: storybook-static-downloaded # Download artifact contents here
+
+      - name: Setup Node.js for Vercel CLI
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel project configuration
+        # This command creates/updates .vercel/project.json in the CWD (repo root)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel
+        id: vercel-deployment
+        # Deploys the content of './storybook-static-downloaded' directory.
+        # Vercel CLI uses the .vercel/project.json from CWD (repo root) for project linking.
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} ./storybook-static-downloaded
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Modify the GitHub Actions workflow to include a new job, `deploy-to-vercel-preview`.

This job:
- Depends on `build-storybook`.
- Downloads the `storybook-static` artifact (uploaded as `github-pages`).
- Uses the Vercel CLI to deploy the prebuilt Storybook to Vercel Preview.
- Requires `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets.

The deployment artifact is routed to the `_storybook` path via Vercel project settings (not directly in the deploy command).