### PR TITLE
Refactor: Use --legacy-format flag in upload translations script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"start": "next start",
 		"lint": "next lint",
 		"test": "vitest",
-		"fbtee:collect": "fbtee collect --fbt-common-path ./common_strings.json --src src",
+		"fbtee:collect": "fbtee collect --fbt-common-path ./common_strings.json --src src --legacy-format",
 		"fbtee:translate": "fbtee translate --translations translations/*.json -o src/translations",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-patchedDependencies:
-  fbtee:
-    hash: 354a4b2c8fd5093c35116dbd67c7d6e84b14e86b971c6cf6a6576e8a276f8829
-    path: patches/fbtee.patch
-
 importers:
 
   .:
@@ -87,7 +82,7 @@ importers:
         version: 3.1.3
       fbtee:
         specifier: ^1.0.0
-        version: 1.2.2(patch_hash=354a4b2c8fd5093c35116dbd67c7d6e84b14e86b971c6cf6a6576e8a276f8829)(@nkzw/babel-plugin-fbtee-runtime@1.2.2(@nkzw/babel-plugin-fbtee@1.2.2))(@nkzw/babel-plugin-fbtee@1.2.2)(react@19.1.0)
+        version: 1.2.2(@nkzw/babel-plugin-fbtee-runtime@1.2.2(@nkzw/babel-plugin-fbtee@1.2.2))(@nkzw/babel-plugin-fbtee@1.2.2)(react@19.1.0)
       jszip:
         specifier: latest
         version: 3.10.1
@@ -10566,7 +10561,7 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fbtee@1.2.2(patch_hash=354a4b2c8fd5093c35116dbd67c7d6e84b14e86b971c6cf6a6576e8a276f8829)(@nkzw/babel-plugin-fbtee-runtime@1.2.2(@nkzw/babel-plugin-fbtee@1.2.2))(@nkzw/babel-plugin-fbtee@1.2.2)(react@19.1.0):
+  fbtee@1.2.2(@nkzw/babel-plugin-fbtee-runtime@1.2.2(@nkzw/babel-plugin-fbtee@1.2.2))(@nkzw/babel-plugin-fbtee@1.2.2)(react@19.1.0):
     dependencies:
       '@nkzw/babel-plugin-fbtee': 1.2.2
       '@nkzw/babel-plugin-fbtee-runtime': 1.2.2(@nkzw/babel-plugin-fbtee@1.2.2)

--- a/scripts/upload-source-strings.sh
+++ b/scripts/upload-source-strings.sh
@@ -5,8 +5,6 @@
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-pnpm run fbtee:collect
-
-jq '.phrases |= map( . + { col_beg: .loc.start.column, col_end: .loc.end.column, line_beg: .loc.start.line, line_end: .loc.end.line, filepath: .filename } | del(.filename, .loc) )' source_strings.json > source_strings.json.tmp && mv source_strings.json.tmp source_strings.json
+pnpm run fbtee:collect --legacy-format
 
 pnpm exec crowdin push -b ${BRANCH_NAME} --plain sources

--- a/scripts/upload-source-strings.sh
+++ b/scripts/upload-source-strings.sh
@@ -5,6 +5,6 @@
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-pnpm run fbtee:collect --legacy-format
+pnpm run fbtee:collect
 
 pnpm exec crowdin push -b ${BRANCH_NAME} --plain sources


### PR DESCRIPTION
Removes the explicit jq transformation in favor of the --legacy-format flag provided by the fbtee:collect script.