### PR TITLE
Refactor: Introduce useResumableSession hook

### DIFF
--- a/src/app/feeding/hooks/use-resumable-session.test.ts
+++ b/src/app/feeding/hooks/use-resumable-session.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { subMinutes } from 'date-fns';
+import { describe, expect, it, vi } from 'vitest';
+import { useLatestFeedingSession } from '@/hooks/use-latest-feeding-session';
+import type { FeedingSession } from '@/types/feeding';
+import { useResumableSession } from './use-resumable-session';
+
+vi.mock('@/hooks/use-latest-feeding-session');
+
+const mockUseLatestFeedingSession = vi.mocked(useLatestFeedingSession);
+
+describe('useResumableSession', () => {
+	it('should return undefined when there is no latest feeding session', () => {
+		mockUseLatestFeedingSession.mockReturnValue(undefined);
+		const { result } = renderHook(() => useResumableSession());
+		expect(result.current).toBeUndefined();
+	});
+
+	it('should return a resumable session if the latest session ended less than 5 minutes ago', () => {
+		const session: FeedingSession = {
+			id: '1',
+			breast: 'left',
+			startTime: new Date().toISOString(),
+			endTime: subMinutes(new Date(), 4).toISOString(),
+			durationInSeconds: 240,
+		};
+		mockUseLatestFeedingSession.mockReturnValue(session);
+		const { result } = renderHook(() => useResumableSession());
+		expect(result.current).toEqual(session);
+	});
+
+	it('should return undefined if the latest session ended more than 5 minutes ago', () => {
+		const session: FeedingSession = {
+			id: '1',
+			breast: 'left',
+			startTime: new Date().toISOString(),
+			endTime: subMinutes(new Date(), 6).toISOString(),
+			durationInSeconds: 360,
+		};
+		mockUseLatestFeedingSession.mockReturnValue(session);
+		const { result } = renderHook(() => useResumableSession());
+		expect(result.current).toBeUndefined();
+	});
+
+	it('should invalidate the session after 5 minutes', () => {
+		vi.useFakeTimers();
+		const session: FeedingSession = {
+			id: '1',
+			breast: 'left',
+			startTime: new Date().toISOString(),
+			endTime: subMinutes(new Date(), 4).toISOString(),
+			durationInSeconds: 240,
+		};
+		mockUseLatestFeedingSession.mockReturnValue(session);
+		const { result } = renderHook(() => useResumableSession());
+		expect(result.current).toEqual(session);
+
+		act(() => {
+			vi.advanceTimersByTime(60 * 1000);
+		});
+
+		expect(result.current).toBeUndefined();
+		vi.useRealTimers();
+	});
+});

--- a/src/app/feeding/hooks/use-resumable-session.ts
+++ b/src/app/feeding/hooks/use-resumable-session.ts
@@ -1,0 +1,38 @@
+import { differenceInMinutes } from 'date-fns';
+import { useEffect, useState } from 'react';
+import { useLatestFeedingSession } from '@/hooks/use-latest-feeding-session';
+import type { FeedingSession } from '@/types/feeding';
+
+const RESUME_WINDOW_IN_MINUTES = 5;
+
+export function useResumableSession(): FeedingSession | undefined {
+	const latestFeedingSession = useLatestFeedingSession();
+	const [resumableSession, setResumableSession] = useState<
+		FeedingSession | undefined
+	>();
+
+	useEffect(() => {
+		if (
+			!latestFeedingSession ||
+			differenceInMinutes(new Date(), new Date(latestFeedingSession.endTime)) >=
+				RESUME_WINDOW_IN_MINUTES
+		) {
+			setResumableSession(undefined);
+			return;
+		}
+
+		setResumableSession(latestFeedingSession);
+
+		const timeUntilExpiry =
+			RESUME_WINDOW_IN_MINUTES * 60 * 1000 -
+			(new Date().getTime() - new Date(latestFeedingSession.endTime).getTime());
+
+		const timer = setTimeout(() => {
+			setResumableSession(undefined);
+		}, timeUntilExpiry);
+
+		return () => clearTimeout(timer);
+	}, [latestFeedingSession]);
+
+	return resumableSession;
+}

--- a/src/app/feeding/page.tsx
+++ b/src/app/feeding/page.tsx
@@ -4,26 +4,26 @@ import { PlusCircle } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useFeedingSessions } from '@/hooks/use-feeding-sessions';
-import { useLatestFeedingSession } from '@/hooks/use-latest-feeding-session';
 import { useNextBreast } from '@/hooks/use-next-breast';
 import FeedingForm from './components/feeding-form';
 import HistoryList from './components/feeding-history-list';
 import BreastfeedingTracker from './components/feeding-tracker';
+import { useResumableSession } from './hooks/use-resumable-session';
 
 export default function Feedings() {
 	const [isAddEntryDialogOpen, setIsAddEntryDialogOpen] = useState(false);
 	const { add, remove, update, value: sessions } = useFeedingSessions();
 	const nextBreast = useNextBreast();
-	const latestFeedingSession = useLatestFeedingSession();
+	const resumableSession = useResumableSession();
 
 	return (
 		<>
 			<div className="w-full">
 				<BreastfeedingTracker
-					latestFeedingSession={latestFeedingSession}
 					nextBreast={nextBreast}
 					onCreateSession={add}
 					onUpdateSession={update}
+					resumableSession={resumableSession}
 				/>
 
 				<div className="w-full mt-8">


### PR DESCRIPTION
This commit refactors the "Resume Last Feeding" feature by introducing a new custom hook, `useResumableSession`.

This hook encapsulates the logic for determining if a feeding session is resumable, which is defined as the last completed feeding session that ended less than 5 minutes ago. The hook automatically invalidates the resumable session state when the 5-minute window expires.

The `BreastfeedingTracker` component has been updated to use this hook, simplifying its logic and improving maintainability. The UI behavior for the "Resume" and "Next" badges remains unchanged.

A test for the new hook has been added to ensure its correctness. The `BreastfeedingTracker` component has also been refactored to remove redundant state.