### PR TITLE
Fix various TypeScript typing errors

### DIFF
--- a/src/app/medication/utils/calculate-next-due.ts
+++ b/src/app/medication/utils/calculate-next-due.ts
@@ -8,7 +8,7 @@ export const calculateNextDue = (regimen: MedicationRegimen): string => {
 		const todayDateStr = now.toISOString().split('T')[0];
 		let nextDueTimeStr = '';
 
-		for (const time of regimen.schedule.times.sort()) {
+		for (const time of [...regimen.schedule.times].sort()) {
 			const [hours, minutes] = time.split(':').map(Number);
 			const potentialNextDue = new Date(todayDateStr);
 			potentialNextDue.setHours(hours, minutes, 0, 0);
@@ -22,7 +22,7 @@ export const calculateNextDue = (regimen: MedicationRegimen): string => {
 			const tomorrow = new Date(now);
 			tomorrow.setDate(now.getDate() + 1);
 			const tomorrowDateStr = tomorrow.toISOString().split('T')[0];
-			const firstTimeTomorrow = regimen.schedule.times.sort()[0];
+			const firstTimeTomorrow = [...regimen.schedule.times].sort()[0];
 			const [hours, minutes] = firstTimeTomorrow.split(':').map(Number);
 			const nextDueTomorrow = new Date(tomorrowDateStr);
 			nextDueTomorrow.setHours(hours, minutes, 0, 0);

--- a/src/app/medication/validation/medication-administration-schema.ts
+++ b/src/app/medication/validation/medication-administration-schema.ts
@@ -2,11 +2,11 @@ import { z } from 'zod';
 
 export const medicationAdministrationSchema = z.object({
 	administrationStatus: z.enum(['On Time', 'Missed', 'Adjusted'], {
-		required_error: 'Administration status is required.',
+		message: 'Administration status is required.',
 	}),
 	details: z.string().optional(),
 	dosageAmount: z
-		.number({ invalid_type_error: 'Dosage amount must be a number.' })
+		.number({ message: 'Dosage amount must be a number.' })
 		.positive({ message: 'Dosage amount must be positive.' }),
 	dosageUnit: z.string().min(1, { message: 'Dosage unit is required.' }),
 	medicationName: z

--- a/src/app/medication/validation/medication-regimen-schema.ts
+++ b/src/app/medication/validation/medication-regimen-schema.ts
@@ -8,9 +8,12 @@ const timeStringSchema = z
 export const medicationRegimenSchema = z
 	.object({
 		asNeededDetails: z.string().optional(),
-		dailyTimes: z.array(z.object({ time: timeStringSchema })).optional(),
+		dailyTimes: z
+			.array(z.object({ time: timeStringSchema }))
+			.readonly()
+			.optional(),
 		dosageAmount: z
-			.number({ invalid_type_error: 'Dosage amount must be a number' })
+			.number({ message: 'Dosage amount must be a number' })
 			.positive({ message: 'Dosage amount must be positive' }),
 		dosageUnit: z.string().min(1, { message: 'Dosage unit is required' }),
 		endDate: z.string().optional(),
@@ -36,8 +39,12 @@ export const medicationRegimenSchema = z
 					'Sunday',
 				]),
 			)
+			.readonly()
 			.optional(),
-		weeklyTimes: z.array(z.object({ time: timeStringSchema })).optional(),
+		weeklyTimes: z
+			.array(z.object({ time: timeStringSchema }))
+			.readonly()
+			.optional(),
 	})
 	.superRefine((data, ctx) => {
 		// Conditional validation based on scheduleType

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,7 +3,7 @@ import { IntlVariations, setupFbtee } from 'fbtee';
 import german from '../translations/de_DE.json';
 
 export const DEFAULT_LOCALE = 'en_US';
-export type Locale = typeof DEFAULT_LOCALE | keyof typeof german;
+export type Locale = typeof DEFAULT_LOCALE | (keyof typeof german & string);
 const LOCAL_STORAGE_KEY = 'preferredLanguage';
 
 function isSupportedLocale(locale: string): locale is Locale {

--- a/src/types/medication-regimen.ts
+++ b/src/types/medication-regimen.ts
@@ -69,7 +69,7 @@ export interface MedicationRegimen {
  */
 export type MedicationSchedule =
 	| {
-			times: string[]; // Array of ISO time strings (e.g., "10:00", "18:30")
+			times: readonly string[]; // Array of ISO time strings (e.g., "10:00", "18:30")
 			type: 'daily'; // e.g., every day at a specific time
 	  }
 	| {
@@ -79,7 +79,7 @@ export type MedicationSchedule =
 			type: 'interval'; // e.g., every X hours/days
 	  }
 	| {
-			daysOfWeek: (
+			daysOfWeek: readonly (
 				| 'Monday'
 				| 'Tuesday'
 				| 'Wednesday'
@@ -88,7 +88,7 @@ export type MedicationSchedule =
 				| 'Saturday'
 				| 'Sunday'
 			)[];
-			times: string[]; // Array of ISO time strings
+			times: readonly string[]; // Array of ISO time strings
 			type: 'weekly'; // e.g., specific days of the week at specific times
 	  }
 	| {


### PR DESCRIPTION
This PR fixes several TypeScript errors found by the checker. Key changes include:
1. **Zod v4 API Updates**: Replaced `required_error` and `invalid_type_error` with `message` in medication schemas to align with Zod v4's more restrictive constructor types.
2. **Immutability Improvements**: Changed array properties in `MedicationRegimen` and `MedicationSchedule` to `readonly`. This resolves assignment errors in `MedicationPage` where Valtio snapshots were being assigned to mutable types.
3. **Safe Sorting**: Updated `calculateNextDue` utility to create a copy before sorting, preventing mutation of `readonly` arrays.
4. **I18n Type Safety**: Constrained the `Locale` type to strings to prevent numeric keys from being inferred from translation JSON files.
5. **Translation Generation**: Ran `fbtee:collect` and `fbtee:translate` to generate `src/translations/de_DE.json`, fixing missing module errors in `src/i18n/index.ts`.

All relevant tests pass, and the TypeScript checker no longer reports errors for the modified files.

---
*PR created automatically by Jules for task [1141602106921960753](https://jules.google.com/task/1141602106921960753) started by @clentfort*