### PR TITLE
feat(partykit): wire preview host and deploys

### DIFF
--- a/.github/workflows/partykit.yaml
+++ b/.github/workflows/partykit.yaml
@@ -3,11 +3,25 @@ name: Deploy PartyKit
 on:
   push:
     branches:
-      - main
+      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: partykit-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      PARTYKIT_ACCOUNT: clentfort
+      PARTYKIT_PROJECT_NAME: adameter-party
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,7 +41,203 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm exec partykit deploy
+      - name: Compute production URL
+        id: production_meta
+        run: |
+          echo "production_url=https://${PARTYKIT_PROJECT_NAME}.${PARTYKIT_ACCOUNT}.partykit.dev" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub deployment
+        id: create_deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'partykit-production',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: false,
+              production_environment: true,
+              description: 'PartyKit production deployment',
+            });
+            return deployment.data.id;
+
+      - name: Mark deployment in progress
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PRODUCTION_URL: ${{ steps.production_meta.outputs.production_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'in_progress',
+              environment_url: process.env.PRODUCTION_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit production deployment in progress',
+            });
+
+      - name: Deploy PartyKit production environment
+        id: deploy_partykit
+        run: pnpm exec partykit deploy
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: ${{ secrets.PARTYKIT_LOGIN  }}
+
+      - name: Mark deployment successful
+        if: always() && steps.deploy_partykit.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PRODUCTION_URL: ${{ steps.production_meta.outputs.production_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'success',
+              environment_url: process.env.PRODUCTION_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit production deployment is ready',
+            });
+
+      - name: Mark deployment failed
+        if: always() && steps.deploy_partykit.outcome != 'success'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PRODUCTION_URL: ${{ steps.production_meta.outputs.production_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'failure',
+              environment_url: process.env.PRODUCTION_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit production deployment failed',
+            });
+
+  deploy-branch-preview:
+    if: |
+      (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    env:
+      PARTYKIT_ACCOUNT: clentfort
+      PARTYKIT_PROJECT_NAME: adameter-party
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Compute preview URLs
+        id: preview_meta
+        env:
+          RAW_REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          SLUG=$(node -e "const raw=process.env.RAW_REF ?? ''; let slug=raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-+/g, '-'); if (!slug) slug='preview'; slug=slug.slice(0, 56).replace(/-+$/g, '') || 'preview'; process.stdout.write(slug);")
+          PREVIEW_NAME="branch-${SLUG}"
+          echo "preview_name=${PREVIEW_NAME}" >> "$GITHUB_OUTPUT"
+          echo "preview_url=https://${PREVIEW_NAME}.${PARTYKIT_PROJECT_NAME}.${PARTYKIT_ACCOUNT}.partykit.dev" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub deployment
+        id: create_deployment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_NAME: ${{ steps.preview_meta.outputs.preview_name }}
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: `partykit-preview/${process.env.PREVIEW_NAME}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+              description: 'PartyKit branch preview deployment',
+            });
+            return deployment.data.id;
+
+      - name: Mark deployment in progress
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PREVIEW_URL: ${{ steps.preview_meta.outputs.preview_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'in_progress',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit branch preview deployment in progress',
+            });
+
+      - name: Deploy PartyKit branch preview
+        id: deploy_partykit
+        env:
+          PREVIEW_NAME: ${{ steps.preview_meta.outputs.preview_name }}
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: ${{ secrets.PARTYKIT_LOGIN  }}
+        run: pnpm exec partykit deploy --preview "$PREVIEW_NAME"
+
+      - name: Mark deployment successful
+        if: always() && steps.deploy_partykit.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PREVIEW_URL: ${{ steps.preview_meta.outputs.preview_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'success',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit branch preview is ready',
+            });
+
+      - name: Mark deployment failed
+        if: always() && steps.deploy_partykit.outcome != 'success'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.result }}
+          PREVIEW_URL: ${{ steps.preview_meta.outputs.preview_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'failure',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'PartyKit branch preview deployment failed',
+            });

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ feature, or improving translations, your help is appreciated.
 6.  **Commit your changes** and **push to your fork.**
 7.  **Open a Pull Request** against the main AdaMeter repository.
 
+### Preview Environments
+
+- Branch previews deploy to PartyKit using the name `branch-<slug>`.
+- Vercel preview builds automatically target
+  `branch-<slug>.adameter-party.clentfort.partykit.dev`.
+- You can override the PartyKit target manually by setting
+  `NEXT_PUBLIC_PARTYKIT_HOST`.
+
 ### Translations
 
 AdaMeter uses `fbtee` for internationalization, making it easy to mark strings

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,51 @@
 import { NextConfig } from 'next';
 
+const PARTYKIT_PROJECT_NAME = 'adameter-party';
+const PARTYKIT_ACCOUNT = 'clentfort';
+
+const getPartykitHostForBuild = () => {
+	const explicitHost = process.env.NEXT_PUBLIC_PARTYKIT_HOST;
+	if (explicitHost) {
+		return explicitHost.replace(/^https?:\/\//, '').replace(/\/$/, '');
+	}
+
+	const vercelEnv = process.env.VERCEL_ENV;
+	const vercelGitCommitRef = process.env.VERCEL_GIT_COMMIT_REF;
+	const previewName =
+		vercelEnv === 'preview' ? getPreviewName(vercelGitCommitRef) : undefined;
+	if (previewName) {
+		return `${previewName}.${PARTYKIT_PROJECT_NAME}.${PARTYKIT_ACCOUNT}.partykit.dev`;
+	}
+
+	return `${PARTYKIT_PROJECT_NAME}.${PARTYKIT_ACCOUNT}.partykit.dev`;
+};
+
+const getPreviewName = (vercelGitCommitRef?: string) => {
+	if (!vercelGitCommitRef) {
+		return undefined;
+	}
+
+	return `branch-${normalizePreviewId(vercelGitCommitRef, 56)}`;
+};
+
+const normalizePreviewId = (value: string, maxLength: number) => {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.replace(/-+/g, '-');
+
+	if (!normalized) {
+		return 'preview';
+	}
+
+	return normalized.slice(0, maxLength).replace(/-+$/g, '') || 'preview';
+};
+
 const nextConfig: NextConfig = {
+	env: {
+		NEXT_PUBLIC_PARTYKIT_HOST: getPartykitHostForBuild(),
+	},
 	eslint: {
 		// Warning: This allows production builds to successfully complete even if
 		// your project has ESLint errors.

--- a/src/contexts/data-synchronization-context.tsx
+++ b/src/contexts/data-synchronization-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import YPartyKitProvider from 'y-partykit/provider';
 import { Doc as YjsDoc } from 'yjs';
+import { PARTYKIT_URL } from '@/lib/partykit-host';
 import {
 	logPerformanceEvent,
 	setCurrentPerformanceRoom,
@@ -80,12 +81,9 @@ function useYPartykitSync(room: string | undefined, doc: YjsDoc) {
 			room,
 		});
 
-		const provider = new YPartyKitProvider(
-			'https://adameter-party.clentfort.partykit.dev',
-			room,
-			doc,
-			{ connect: true },
-		);
+		const provider = new YPartyKitProvider(PARTYKIT_URL, room, doc, {
+			connect: true,
+		});
 
 		connectTimer.end();
 		logPerformanceEvent('sync.partykit.provider.created', {

--- a/src/lib/partykit-host.test.ts
+++ b/src/lib/partykit-host.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePartykitHost } from './partykit-host';
+
+describe('resolvePartykitHost', () => {
+	it('returns production host by default', () => {
+		expect(resolvePartykitHost()).toBe('adameter-party.clentfort.partykit.dev');
+	});
+
+	it('returns per-branch preview host on vercel branch previews', () => {
+		expect(
+			resolvePartykitHost({
+				vercelEnv: 'preview',
+				vercelGitCommitRef: 'feat/partykit-preview',
+			}),
+		).toBe(
+			'branch-feat-partykit-preview.adameter-party.clentfort.partykit.dev',
+		);
+	});
+
+	it('sanitizes long branch names for preview hosts', () => {
+		const host = resolvePartykitHost({
+			vercelEnv: 'preview',
+			vercelGitCommitRef:
+				'feature/This Is a Very Very Long Branch Name __ With Symbols!!! and More',
+		});
+
+		expect(host).toMatch(
+			/^branch-[a-z0-9-]+\.adameter-party\.clentfort\.partykit\.dev$/,
+		);
+		expect(host.length).toBeLessThanOrEqual(110);
+	});
+
+	it('normalizes explicit host values', () => {
+		expect(
+			resolvePartykitHost({
+				explicitHost: 'https://custom.adameter.example/',
+			}),
+		).toBe('custom.adameter.example');
+	});
+});

--- a/src/lib/partykit-host.ts
+++ b/src/lib/partykit-host.ts
@@ -1,0 +1,77 @@
+const PARTYKIT_PROJECT_NAME = 'adameter-party';
+const PARTYKIT_ACCOUNT = 'clentfort';
+const PARTYKIT_DOMAIN_SUFFIX = 'partykit.dev';
+
+interface ResolvePartykitHostOptions {
+	explicitHost?: string;
+	vercelEnv?: string;
+	vercelGitCommitRef?: string;
+}
+
+export function resolvePartykitHost({
+	explicitHost,
+	vercelEnv,
+	vercelGitCommitRef,
+}: ResolvePartykitHostOptions = {}) {
+	if (explicitHost) {
+		return normalizePartykitHost(explicitHost);
+	}
+
+	const previewName =
+		vercelEnv === 'preview' ? getPreviewName(vercelGitCommitRef) : undefined;
+	if (previewName) {
+		return [
+			previewName,
+			PARTYKIT_PROJECT_NAME,
+			PARTYKIT_ACCOUNT,
+			PARTYKIT_DOMAIN_SUFFIX,
+		].join('.');
+	}
+
+	return [PARTYKIT_PROJECT_NAME, PARTYKIT_ACCOUNT, PARTYKIT_DOMAIN_SUFFIX].join(
+		'.',
+	);
+}
+
+export function getPartykitHostFromEnv(env: NodeJS.ProcessEnv = process.env) {
+	return resolvePartykitHost({
+		explicitHost: env.NEXT_PUBLIC_PARTYKIT_HOST,
+		vercelEnv: env.VERCEL_ENV,
+		vercelGitCommitRef: env.VERCEL_GIT_COMMIT_REF,
+	});
+}
+
+const NEXT_PUBLIC_PARTYKIT_HOST = process.env.NEXT_PUBLIC_PARTYKIT_HOST;
+
+export const PARTYKIT_HOST = resolvePartykitHost({
+	explicitHost: NEXT_PUBLIC_PARTYKIT_HOST,
+	vercelEnv: process.env.VERCEL_ENV,
+	vercelGitCommitRef: process.env.VERCEL_GIT_COMMIT_REF,
+});
+export const PARTYKIT_URL = `https://${PARTYKIT_HOST}`;
+
+function normalizePartykitHost(host: string) {
+	return host.replace(/^https?:\/\//, '').replace(/\/$/, '');
+}
+
+function getPreviewName(vercelGitCommitRef?: string) {
+	if (!vercelGitCommitRef) {
+		return undefined;
+	}
+
+	return `branch-${normalizePreviewId(vercelGitCommitRef, 56)}`;
+}
+
+function normalizePreviewId(value: string, maxLength: number) {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.replace(/-+/g, '-');
+
+	if (!normalized) {
+		return 'preview';
+	}
+
+	return normalized.slice(0, maxLength).replace(/-+$/g, '') || 'preview';
+}


### PR DESCRIPTION
Resolve PartyKit hosts from Vercel preview metadata so each PR build targets its matching PartyKit preview, with a manual NEXT_PUBLIC_PARTYKIT_HOST override.\n\nAdd GitHub Actions deployment tracking for both PR preview and main production PartyKit deploys, and document the preview mapping behavior.