### PR TITLE
fix(sync): guard Tinybase remote bootstrap

### DIFF
--- a/src/lib/tinybase-sync/remote-bootstrap.test.ts
+++ b/src/lib/tinybase-sync/remote-bootstrap.test.ts
@@ -1,0 +1,72 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import { ROW_JSON_CELL, ROW_ORDER_CELL, TABLE_IDS } from './constants';
+import {
+	reconcileRemoteLoadResult,
+	snapshotStoreContentIfNonEmpty,
+} from './remote-bootstrap';
+
+describe('remote-bootstrap', () => {
+	it('restores local snapshot when remote load is empty', () => {
+		const store = createStore();
+		setEventRow(store, 'local');
+
+		const localSnapshot = snapshotStoreContentIfNonEmpty(store);
+		store.delTables();
+
+		const result = reconcileRemoteLoadResult(store, localSnapshot);
+
+		expect(result).toEqual({
+			decision: 'restore-local',
+			localHadData: true,
+			remoteHadData: false,
+		});
+		expect(store.getRowCount(TABLE_IDS.EVENTS)).toBe(1);
+		expect(store.hasRow(TABLE_IDS.EVENTS, 'local')).toBe(true);
+	});
+
+	it('keeps remote data when remote load is non-empty', () => {
+		const store = createStore();
+		setEventRow(store, 'local');
+		const localSnapshot = snapshotStoreContentIfNonEmpty(store);
+
+		store.delTables();
+		setEventRow(store, 'remote');
+
+		const result = reconcileRemoteLoadResult(store, localSnapshot);
+
+		expect(result).toEqual({
+			decision: 'keep-remote',
+			localHadData: true,
+			remoteHadData: true,
+		});
+		expect(store.getRowCount(TABLE_IDS.EVENTS)).toBe(1);
+		expect(store.hasRow(TABLE_IDS.EVENTS, 'remote')).toBe(true);
+		expect(store.hasRow(TABLE_IDS.EVENTS, 'local')).toBe(false);
+	});
+
+	it('stays empty when both local and remote are empty', () => {
+		const store = createStore();
+
+		const result = reconcileRemoteLoadResult(store, undefined);
+
+		expect(result).toEqual({
+			decision: 'keep-empty',
+			localHadData: false,
+			remoteHadData: false,
+		});
+		expect(store.getRowCount(TABLE_IDS.EVENTS)).toBe(0);
+	});
+});
+
+function setEventRow(store: ReturnType<typeof createStore>, id: string) {
+	store.setRow(TABLE_IDS.EVENTS, id, {
+		[ROW_JSON_CELL]: JSON.stringify({
+			id,
+			startDate: '2026-02-08T00:00:00.000Z',
+			title: id,
+			type: 'point',
+		}),
+		[ROW_ORDER_CELL]: 0,
+	});
+}

--- a/src/lib/tinybase-sync/remote-bootstrap.ts
+++ b/src/lib/tinybase-sync/remote-bootstrap.ts
@@ -1,0 +1,56 @@
+import type { Content, Store } from 'tinybase';
+import { isStoreDataEmpty } from './legacy-yjs-migration';
+
+type RemoteBootstrapDecision = 'keep-empty' | 'keep-remote' | 'restore-local';
+
+interface RemoteBootstrapResult {
+	decision: RemoteBootstrapDecision;
+	localHadData: boolean;
+	remoteHadData: boolean;
+}
+
+export function snapshotStoreContentIfNonEmpty(
+	store: Store,
+): Content | undefined {
+	if (isStoreDataEmpty(store)) {
+		return undefined;
+	}
+
+	const content = store.getContent();
+	if (typeof structuredClone === 'function') {
+		return structuredClone(content);
+	}
+
+	return content;
+}
+
+export function reconcileRemoteLoadResult(
+	store: Store,
+	localSnapshot: Content | undefined,
+): RemoteBootstrapResult {
+	const remoteHadData = !isStoreDataEmpty(store);
+	const localHadData = localSnapshot !== undefined;
+
+	if (localHadData && !remoteHadData) {
+		store.setContent(localSnapshot);
+		return {
+			decision: 'restore-local',
+			localHadData,
+			remoteHadData,
+		};
+	}
+
+	if (remoteHadData) {
+		return {
+			decision: 'keep-remote',
+			localHadData,
+			remoteHadData,
+		};
+	}
+
+	return {
+		decision: 'keep-empty',
+		localHadData,
+		remoteHadData,
+	};
+}


### PR DESCRIPTION
Avoid destructive first-load sync behavior by snapshotting non-empty local Tinybase content before loading PartyKit data and restoring it when remote state is empty. This preserves migrated local data while still preferring remote content when it already exists.