### PR TITLE
fix: restore daily feeding distribution heat map

### DIFF
--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -17,6 +17,7 @@ import DiaperStats from './components/diaper-stats';
 import DurationStats from './components/duration-stats';
 import FeedingsPerDayStats from './components/feedings-per-day-stats';
 import GrowthChart from './components/growth-chart';
+import HeatMap from './components/heat-map';
 import TimeBetweenStats from './components/time-between-stats';
 import TotalDurationStats from './components/total-duration-stats';
 import TotalFeedingsStats from './components/total-feedings-stats';
@@ -122,6 +123,7 @@ export default function StatisticsPage() {
 								<TimeBetweenStats sessions={filteredSessions} />
 								<FeedingsPerDayStats sessions={filteredSessions} />
 								<TotalFeedingsStats sessions={filteredSessions} />
+								<HeatMap className="col-span-2" sessions={filteredSessions} />
 							</div>
 							<YearlyActivityHeatMap
 								className="mt-4"


### PR DESCRIPTION
## Summary
- restore the original daily feeding distribution heat map card in statistics
- add the `HeatMap` component back to the feeding stats grid so time-of-day distribution remains visible
- keep the yearly activity heat maps intact while restoring the removed visualization