### PR TITLE
Refactor forms to react-hook-form + zod uniformly

### DIFF
--- a/src/app/diaper/components/diaper-form.test.tsx
+++ b/src/app/diaper/components/diaper-form.test.tsx
@@ -1,0 +1,87 @@
+import type { DiaperChange } from '@/types/diaper';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DiaperForm from './diaper-form';
+
+vi.mock('@/hooks/use-diaper-changes', () => ({
+	useDiaperChanges: () => ({
+		value: [],
+	}),
+}));
+
+vi.mock('@/hooks/use-diaper-products', () => ({
+	useDiaperProducts: () => ({
+		add: vi.fn(),
+		value: [
+			{ id: '1', isReusable: false, name: 'Product 1' },
+			{ id: '2', isReusable: true, name: 'Product 2' },
+		],
+	}),
+}));
+
+describe('DiaperForm', () => {
+	const mockOnSave = vi.fn();
+	const mockOnClose = vi.fn();
+
+	const baseProps = {
+		onClose: mockOnClose,
+		onSave: mockOnSave,
+		title: 'Add Diaper Change',
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders with initial data and calls onSave when submitted', async () => {
+		const initialChange: DiaperChange = {
+			containsStool: true,
+			containsUrine: true,
+			id: '1',
+			leakage: false,
+			notes: 'Some notes',
+			pottyStool: false,
+			pottyUrine: false,
+			temperature: 37,
+			timestamp: '2023-10-27T10:00:00.000Z',
+		};
+
+		render(<DiaperForm {...baseProps} change={initialChange} />);
+
+		expect(screen.getByLabelText(/temperature/i)).toHaveValue(37);
+		expect(screen.getByLabelText(/notes/i)).toHaveValue('Some notes');
+
+		fireEvent.click(screen.getByTestId('save-button'));
+
+		await waitFor(() => expect(mockOnSave).toHaveBeenCalledTimes(1));
+		const savedChange = mockOnSave.mock.calls[0][0];
+		expect(savedChange.containsStool).toBe(true);
+		expect(savedChange.containsUrine).toBe(true);
+		expect(savedChange.temperature).toBe(37);
+		expect(savedChange.notes).toBe('Some notes');
+		expect(savedChange.id).toBe('1');
+	});
+
+	it('allows toggling urine and stool', async () => {
+		render(<DiaperForm {...baseProps} />);
+
+		fireEvent.click(screen.getByTestId('toggle-diaper-urine'));
+		fireEvent.click(screen.getByTestId('toggle-diaper-stool'));
+		fireEvent.click(screen.getByTestId('save-button'));
+
+		await waitFor(() => expect(mockOnSave).toHaveBeenCalledTimes(1));
+		const savedChange = mockOnSave.mock.calls[0][0];
+		expect(savedChange.containsUrine).toBe(false);
+		expect(savedChange.containsStool).toBe(true);
+	});
+});

--- a/src/app/diaper/components/diaper-form.tsx
+++ b/src/app/diaper/components/diaper-form.tsx
@@ -1,7 +1,10 @@
-import type { DiaperChange } from '@/types/diaper';
+import type { ReactNode } from 'react';
+import type { DiaperChange, DiaperFormValues } from '@/types/diaper';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
 import { Plus } from 'lucide-react';
-import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import ProductForm from '@/components/product-form';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,6 +27,7 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { useDiaperChanges } from '@/hooks/use-diaper-changes';
 import { useDiaperProducts } from '@/hooks/use-diaper-products';
+import { diaperFormSchema } from '@/types/diaper';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
 import { dateToTimeInputValue } from '@/utils/date-to-time-input-value';
 import { getFrecencySortedProducts } from '../utils/get-frecency-sorted-products';
@@ -46,6 +50,29 @@ export interface EditDiaperProps {
 
 type DiaperFormProps = AddDiaperProps | EditDiaperProps;
 
+function getDefaultValues(
+	change: DiaperChange | undefined,
+	presetDiaperProductId: string | undefined,
+	presetType: 'stool' | 'urine' | undefined,
+): DiaperFormValues {
+	return {
+		containsStool: change?.containsStool ?? presetType === 'stool',
+		containsUrine:
+			change?.containsUrine ??
+			(presetType === undefined ||
+				presetType === 'urine' ||
+				presetType === 'stool'),
+		date: dateToDateInputValue(change?.timestamp ?? new Date()),
+		diaperProductId: change?.diaperProductId ?? presetDiaperProductId ?? '',
+		leakage: change?.leakage ?? false,
+		notes: change?.notes ?? '',
+		pottyStool: change?.pottyStool ?? false,
+		pottyUrine: change?.pottyUrine ?? false,
+		temperature: change?.temperature?.toString() ?? '',
+		time: dateToTimeInputValue(change?.timestamp ?? new Date()),
+	};
+}
+
 export default function DiaperForm(props: AddDiaperProps): ReactNode;
 export default function DiaperForm(props: EditDiaperProps): ReactNode;
 export default function DiaperForm({
@@ -54,35 +81,6 @@ export default function DiaperForm({
 	title,
 	...props
 }: DiaperFormProps) {
-	const [date, setDate] = useState(
-		'change' in props
-			? dateToDateInputValue(props.change.timestamp)
-			: dateToDateInputValue(new Date()),
-	);
-	const [time, setTime] = useState(
-		'change' in props
-			? dateToTimeInputValue(props.change.timestamp)
-			: dateToTimeInputValue(new Date()),
-	);
-	const [containsUrine, setContainsUrine] = useState(
-		'change' in props
-			? props.change.containsUrine
-			: props.presetType === undefined ||
-					props.presetType === 'urine' ||
-					props.presetType === 'stool',
-	);
-	const [containsStool, setContainsStool] = useState(
-		'change' in props
-			? props.change.containsStool
-			: props.presetType === 'stool',
-	);
-	const [pottyUrine, setPottyUrine] = useState(
-		'change' in props ? (props.change.pottyUrine ?? false) : false,
-	);
-	const [pottyStool, setPottyStool] = useState(
-		'change' in props ? (props.change.pottyStool ?? false) : false,
-	);
-
 	const { add: addProduct, value: products } = useDiaperProducts();
 	const { value: changes } = useDiaperChanges();
 
@@ -91,62 +89,54 @@ export default function DiaperForm({
 		[products, changes],
 	);
 
-	const [diaperProductId, setDiaperProductId] = useState(
-		'change' in props
-			? props.change.diaperProductId
-			: props.presetDiaperProductId,
-	);
 	const [isAddingProduct, setIsAddingProduct] = useState(false);
-
-	const [temperature, setTemperature] = useState(
-		'change' in props ? props.change.temperature?.toString() || '' : '',
-	);
-	const [hasLeakage, setHasLeakage] = useState(
-		'change' in props ? (props.change.leakage ?? false) : false,
-	);
-	const [notes, setNotes] = useState(
-		'change' in props ? (props.change.notes ?? '') : '',
-	);
-
 	const change = 'change' in props ? props.change : undefined;
 
+	const presetDiaperProductId =
+		'presetDiaperProductId' in props ? props.presetDiaperProductId : undefined;
+	const presetType = 'presetType' in props ? props.presetType : undefined;
+
+	const { handleSubmit, register, reset, setValue, watch } =
+		useForm<DiaperFormValues>({
+			defaultValues: getDefaultValues(
+				change,
+				presetDiaperProductId,
+				presetType,
+			),
+			mode: 'onChange',
+			resolver: zodResolver(diaperFormSchema),
+		});
+
+	const containsUrine = watch('containsUrine');
+	const containsStool = watch('containsStool');
+	const pottyUrine = watch('pottyUrine');
+	const pottyStool = watch('pottyStool');
+	const hasLeakage = watch('leakage');
+	const diaperProductId = watch('diaperProductId');
+	const temperature = watch('temperature');
+
 	useEffect(() => {
-		if (!change) {
-			return;
-		}
+		reset(getDefaultValues(change, presetDiaperProductId, presetType));
+	}, [change, presetDiaperProductId, presetType, reset]);
 
-		const changeDate = new Date(change.timestamp);
-		setDate(dateToDateInputValue(changeDate));
-		setTime(dateToTimeInputValue(changeDate));
-		setContainsUrine(change.containsUrine);
-		setContainsStool(change.containsStool);
-		setPottyUrine(change.pottyUrine ?? false);
-		setPottyStool(change.pottyStool ?? false);
-		setDiaperProductId(change.diaperProductId);
-
-		setTemperature(change.temperature ? change.temperature.toString() : '');
-		setHasLeakage(change.leakage || false);
-		setNotes(change.notes || '');
-	}, [change]);
-
-	const handleSubmit = () => {
-		if (!date || !time) return;
-
-		const [year, month, day] = date.split('-').map(Number);
-		const [hours, minutes] = time.split(':').map(Number);
+	const handleSave = (values: DiaperFormValues) => {
+		const [year, month, day] = values.date.split('-').map(Number);
+		const [hours, minutes] = values.time.split(':').map(Number);
 		const timestamp = new Date(year, month - 1, day, hours, minutes);
 
 		const updatedChange: DiaperChange = {
 			...change,
-			containsStool,
-			containsUrine,
-			diaperProductId: diaperProductId || undefined,
+			containsStool: values.containsStool,
+			containsUrine: values.containsUrine,
+			diaperProductId: values.diaperProductId || undefined,
 			id: change?.id || Date.now().toString(),
-			leakage: hasLeakage || undefined,
-			notes: notes || undefined,
-			pottyStool,
-			pottyUrine,
-			temperature: temperature ? Number.parseFloat(temperature) : undefined,
+			leakage: values.leakage || undefined,
+			notes: values.notes || undefined,
+			pottyStool: values.pottyStool,
+			pottyUrine: values.pottyUrine,
+			temperature: values.temperature
+				? Number.parseFloat(values.temperature)
+				: undefined,
 			timestamp: timestamp.toISOString(),
 		};
 
@@ -160,231 +150,249 @@ export default function DiaperForm({
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>
 				</DialogHeader>
-				<div className="grid gap-4 py-2">
-					<div className="space-y-3">
-						<div className="grid grid-cols-3 gap-3 items-center">
-							<div />
-							<div className="text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-								<fbt desc="Urine column header">Urine</fbt>
-							</div>
-							<div className="text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-								<fbt desc="Stool column header">Stool</fbt>
-							</div>
+				<form onSubmit={handleSubmit(handleSave)}>
+					<div className="grid gap-4 py-2">
+						<div className="space-y-3">
+							<div className="grid grid-cols-3 gap-3 items-center">
+								<div />
+								<div className="text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+									<fbt desc="Urine column header">Urine</fbt>
+								</div>
+								<div className="text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+									<fbt desc="Stool column header">Stool</fbt>
+								</div>
 
-							<div className="text-sm font-medium">
-								<fbt desc="Label for the diaper row in the contents matrix">
-									Diaper
-								</fbt>
-							</div>
-							<Button
-								className={`h-12 w-full transition-all ${
-									containsUrine
-										? 'bg-yellow-400 hover:bg-yellow-500 text-yellow-900 shadow-xs ring-2 ring-yellow-600 ring-offset-1'
-										: 'bg-background hover:bg-muted text-muted-foreground'
-								}`}
-								data-testid="toggle-diaper-urine"
-								onClick={() => setContainsUrine(!containsUrine)}
-								type="button"
-								variant="outline"
-							>
-								<span className="text-xl">💧</span>
-							</Button>
-							<Button
-								className={`h-12 w-full transition-all ${
-									containsStool
-										? 'bg-amber-700 hover:bg-amber-800 text-white shadow-xs ring-2 ring-amber-900 ring-offset-1'
-										: 'bg-background hover:bg-muted text-muted-foreground'
-								}`}
-								data-testid="toggle-diaper-stool"
-								onClick={() => setContainsStool(!containsStool)}
-								type="button"
-								variant="outline"
-							>
-								<span className="text-xl">💩</span>
-							</Button>
-
-							<div className="text-sm font-medium">
-								<fbt desc="Label for the potty row in the contents matrix">
-									Potty
-								</fbt>
-							</div>
-							<Button
-								className={`h-12 w-full transition-all ${
-									pottyUrine
-										? 'bg-yellow-400 hover:bg-yellow-500 text-yellow-900 shadow-xs ring-2 ring-yellow-600 ring-offset-1'
-										: 'bg-background hover:bg-muted text-muted-foreground'
-								}`}
-								data-testid="toggle-potty-urine"
-								onClick={() => setPottyUrine(!pottyUrine)}
-								type="button"
-								variant="outline"
-							>
-								<span className="text-xl">💧</span>
-							</Button>
-							<Button
-								className={`h-12 w-full transition-all ${
-									pottyStool
-										? 'bg-amber-700 hover:bg-amber-800 text-white shadow-xs ring-2 ring-amber-900 ring-offset-1'
-										: 'bg-background hover:bg-muted text-muted-foreground'
-								}`}
-								data-testid="toggle-potty-stool"
-								onClick={() => setPottyStool(!pottyStool)}
-								type="button"
-								variant="outline"
-							>
-								<span className="text-xl">💩</span>
-							</Button>
-						</div>
-
-						<div className="flex items-center space-x-2">
-							<Switch
-								checked={hasLeakage}
-								id="edit-leakage"
-								onCheckedChange={setHasLeakage}
-							/>
-							<Label htmlFor="edit-leakage">
-								<fbt desc="Label for a switch button that indicates that a diaper has leaked">
-									Diaper leaked
-								</fbt>
-							</Label>
-						</div>
-					</div>
-
-					<div className="grid grid-cols-2 gap-4">
-						<div className="space-y-2">
-							<Label htmlFor="edit-date">
-								<fbt common>Date</fbt>
-							</Label>
-							<Input
-								id="edit-date"
-								onChange={(e) => setDate(e.target.value)}
-								type="date"
-								value={date}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="edit-time">
-								<fbt common>Time</fbt>
-							</Label>
-							<Input
-								id="edit-time"
-								onChange={(e) => setTime(e.target.value)}
-								type="time"
-								value={time}
-							/>
-						</div>
-					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor="edit-diaper-product">
-							<fbt desc="Label on a select that allows the user to pick a diaper product">
-								Product
-							</fbt>
-						</Label>
-						<div className="flex gap-2">
-							<div className="flex-grow">
-								<Select
-									onValueChange={(value) =>
-										setDiaperProductId(value ?? undefined)
-									}
-									value={diaperProductId}
-								>
-									<SelectTrigger id="edit-diaper-product">
-										<SelectValue
-											placeholder={
-												<fbt desc="Placeholder text on a select that allows the user to pick a diaper product">
-													Select Product
-												</fbt>
-											}
-										/>
-									</SelectTrigger>
-									<SelectContent>
-										{sortedProducts
-											.filter(
-												(p) =>
-													!p.archived ||
-													p.id === diaperProductId ||
-													p.id === change?.diaperProductId,
-											)
-											.map((product) => (
-												<SelectItem key={product.id} value={product.id}>
-													{product.name}
-												</SelectItem>
-											))}
-									</SelectContent>
-								</Select>
-							</div>
-							<Button
-								onClick={() => setIsAddingProduct(true)}
-								size="icon"
-								type="button"
-								variant="outline"
-							>
-								<Plus className="h-4 w-4" />
-							</Button>
-						</div>
-					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor="edit-temperature">
-							<fbt desc="Label on an input to specificy the body temperature in degree Celsius">
-								Temperature (°C)
-							</fbt>
-						</Label>
-						<Input
-							className={
-								temperature &&
-								isAbnormalTemperature(Number.parseFloat(temperature))
-									? 'border-red-500'
-									: ''
-							}
-							id="edit-temperature"
-							onChange={(e) => setTemperature(e.target.value)}
-							placeholder={fbt(
-								'e.g. 37.2',
-								'Placeholder text for an input to set the body temperature in degree Celsius',
-							)}
-							step="0.1"
-							type="number"
-							value={temperature}
-						/>
-						{temperature &&
-							isAbnormalTemperature(Number.parseFloat(temperature)) && (
-								<p className="text-xs text-red-500 mt-1">
-									<fbt desc="A warning that the temperature is outside the normal range">
-										Warning: Temperature outside normal range (36.5°C - 37.5°C)
+								<div className="text-sm font-medium">
+									<fbt desc="Label for the diaper row in the contents matrix">
+										Diaper
 									</fbt>
-								</p>
-							)}
-					</div>
+								</div>
+								<Button
+									className={`h-12 w-full transition-all ${
+										containsUrine
+											? 'bg-yellow-400 hover:bg-yellow-500 text-yellow-900 shadow-xs ring-2 ring-yellow-600 ring-offset-1'
+											: 'bg-background hover:bg-muted text-muted-foreground'
+									}`}
+									data-testid="toggle-diaper-urine"
+									onClick={() => {
+										setValue('containsUrine', !containsUrine, {
+											shouldValidate: true,
+										});
+									}}
+									type="button"
+									variant="outline"
+								>
+									<span className="text-xl">💧</span>
+								</Button>
+								<Button
+									className={`h-12 w-full transition-all ${
+										containsStool
+											? 'bg-amber-700 hover:bg-amber-800 text-white shadow-xs ring-2 ring-amber-900 ring-offset-1'
+											: 'bg-background hover:bg-muted text-muted-foreground'
+									}`}
+									data-testid="toggle-diaper-stool"
+									onClick={() => {
+										setValue('containsStool', !containsStool, {
+											shouldValidate: true,
+										});
+									}}
+									type="button"
+									variant="outline"
+								>
+									<span className="text-xl">💩</span>
+								</Button>
 
-					<div className="space-y-2">
-						<Label htmlFor="edit-notes">
-							<fbt desc="Label for a textbox to note any notes">Notes</fbt>
-						</Label>
-						<Textarea
-							id="edit-notes"
-							onChange={(e) => setNotes(e.target.value)}
-							placeholder={fbt(
-								'e.g. redness, rash, etc.',
-								'Placeholder text for a textbox to note any notes',
-							)}
-							value={notes}
-						/>
+								<div className="text-sm font-medium">
+									<fbt desc="Label for the potty row in the contents matrix">
+										Potty
+									</fbt>
+								</div>
+								<Button
+									className={`h-12 w-full transition-all ${
+										pottyUrine
+											? 'bg-yellow-400 hover:bg-yellow-500 text-yellow-900 shadow-xs ring-2 ring-yellow-600 ring-offset-1'
+											: 'bg-background hover:bg-muted text-muted-foreground'
+									}`}
+									data-testid="toggle-potty-urine"
+									onClick={() => {
+										setValue('pottyUrine', !pottyUrine, {
+											shouldValidate: true,
+										});
+									}}
+									type="button"
+									variant="outline"
+								>
+									<span className="text-xl">💧</span>
+								</Button>
+								<Button
+									className={`h-12 w-full transition-all ${
+										pottyStool
+											? 'bg-amber-700 hover:bg-amber-800 text-white shadow-xs ring-2 ring-amber-900 ring-offset-1'
+											: 'bg-background hover:bg-muted text-muted-foreground'
+									}`}
+									data-testid="toggle-potty-stool"
+									onClick={() => {
+										setValue('pottyStool', !pottyStool, {
+											shouldValidate: true,
+										});
+									}}
+									type="button"
+									variant="outline"
+								>
+									<span className="text-xl">💩</span>
+								</Button>
+							</div>
+
+							<div className="flex items-center space-x-2">
+								<Switch
+									checked={hasLeakage}
+									id="edit-leakage"
+									onCheckedChange={(checked) => {
+										setValue('leakage', checked, { shouldValidate: true });
+									}}
+								/>
+								<Label htmlFor="edit-leakage">
+									<fbt desc="Label for a switch button that indicates that a diaper has leaked">
+										Diaper leaked
+									</fbt>
+								</Label>
+							</div>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<div className="space-y-2">
+								<Label htmlFor="edit-date">
+									<fbt common>Date</fbt>
+								</Label>
+								<Input id="edit-date" type="date" {...register('date')} />
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="edit-time">
+									<fbt common>Time</fbt>
+								</Label>
+								<Input id="edit-time" type="time" {...register('time')} />
+							</div>
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="edit-diaper-product">
+								<fbt desc="Label on a select that allows the user to pick a diaper product">
+									Product
+								</fbt>
+							</Label>
+							<div className="flex gap-2">
+								<div className="flex-grow">
+									<Select
+										onValueChange={(value) => {
+											setValue('diaperProductId', value ?? '', {
+												shouldValidate: true,
+											});
+										}}
+										value={diaperProductId}
+									>
+										<SelectTrigger id="edit-diaper-product">
+											<SelectValue
+												placeholder={
+													<fbt desc="Placeholder text on a select that allows the user to pick a diaper product">
+														Select Product
+													</fbt>
+												}
+											/>
+										</SelectTrigger>
+										<SelectContent>
+											{sortedProducts
+												.filter(
+													(product) =>
+														!product.archived ||
+														product.id === diaperProductId ||
+														product.id === change?.diaperProductId,
+												)
+												.map((product) => (
+													<SelectItem key={product.id} value={product.id}>
+														{product.name}
+													</SelectItem>
+												))}
+										</SelectContent>
+									</Select>
+								</div>
+								<Button
+									onClick={() => setIsAddingProduct(true)}
+									size="icon"
+									type="button"
+									variant="outline"
+								>
+									<Plus className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="edit-temperature">
+								<fbt desc="Label on an input to specificy the body temperature in degree Celsius">
+									Temperature (°C)
+								</fbt>
+							</Label>
+							<Input
+								className={
+									temperature &&
+									isAbnormalTemperature(Number.parseFloat(temperature))
+										? 'border-red-500'
+										: ''
+								}
+								id="edit-temperature"
+								placeholder={fbt(
+									'e.g. 37.2',
+									'Placeholder text for an input to set the body temperature in degree Celsius',
+								)}
+								step="0.1"
+								type="number"
+								{...register('temperature')}
+							/>
+							{temperature &&
+								isAbnormalTemperature(Number.parseFloat(temperature)) && (
+									<p className="text-xs text-red-500 mt-1">
+										<fbt desc="A warning that the temperature is outside the normal range">
+											Warning: Temperature outside normal range (36.5°C -
+											37.5°C)
+										</fbt>
+									</p>
+								)}
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="edit-notes">
+								<fbt desc="Label for a textbox to note any notes">Notes</fbt>
+							</Label>
+							<Textarea
+								id="edit-notes"
+								placeholder={fbt(
+									'e.g. redness, rash, etc.',
+									'Placeholder text for a textbox to note any notes',
+								)}
+								{...register('notes')}
+							/>
+						</div>
 					</div>
-				</div>
-				<DialogFooter>
-					<Button onClick={onClose} variant="outline">
-						<fbt common>Cancel</fbt>
-					</Button>
-					<Button data-testid="save-button" onClick={handleSubmit}>
-						<fbt common>Save</fbt>
-					</Button>
-				</DialogFooter>
+					<DialogFooter>
+						<Button onClick={onClose} type="button" variant="outline">
+							<fbt common>Cancel</fbt>
+						</Button>
+						<Button data-testid="save-button" type="submit">
+							<fbt common>Save</fbt>
+						</Button>
+					</DialogFooter>
+				</form>
 			</DialogContent>
 
 			{isAddingProduct && (
-				<Dialog onOpenChange={setIsAddingProduct} open={true}>
+				<Dialog
+					onOpenChange={(open) => {
+						if (!open) {
+							setIsAddingProduct(false);
+						}
+					}}
+					open={true}
+				>
 					<DialogContent className="sm:max-w-[425px]">
 						<DialogHeader>
 							<DialogTitle>
@@ -397,7 +405,9 @@ export default function DiaperForm({
 							onCancel={() => setIsAddingProduct(false)}
 							onSave={(product) => {
 								addProduct(product);
-								setDiaperProductId(product.id);
+								setValue('diaperProductId', product.id, {
+									shouldValidate: true,
+								});
 								setIsAddingProduct(false);
 							}}
 						/>

--- a/src/app/events/components/event-form.tsx
+++ b/src/app/events/components/event-form.tsx
@@ -1,6 +1,9 @@
-import type { Event } from '@/types/event';
+import type { ReactNode } from 'react';
+import type { Event, EventFormValues } from '@/types/event';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
-import { ReactNode, useState } from 'react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -14,6 +17,7 @@ import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { eventFormSchema } from '@/types/event';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
 import { dateToTimeInputValue } from '@/utils/date-to-time-input-value';
 
@@ -30,7 +34,7 @@ interface EditEventFormProps {
 	title: ReactNode;
 }
 
-type EventFromProps = EditEventFormProps | AddEventFormProps;
+type EventFromProps = AddEventFormProps | EditEventFormProps;
 
 const COLORS = [
 	'#6366f1',
@@ -41,71 +45,62 @@ const COLORS = [
 	'#8b5cf6',
 ];
 
+function getDefaultValues(event: Event | undefined): EventFormValues {
+	return {
+		color: event?.color ?? COLORS[0],
+		description: event?.description ?? '',
+		endDate: dateToDateInputValue(event?.endDate ?? new Date()),
+		endTime: dateToTimeInputValue(event?.endDate ?? new Date()),
+		hasEndDate: !!event?.endDate,
+		startDate: dateToDateInputValue(event?.startDate ?? new Date()),
+		startTime: dateToTimeInputValue(event?.startDate ?? new Date()),
+		title: event?.title ?? '',
+		type: event?.type ?? 'point',
+	};
+}
+
 export default function EventForm({
 	onClose,
 	onSave,
 	title: dialogTitle,
 	...props
 }: EventFromProps) {
-	const [eventTitle, setEventTitle] = useState(
-		'event' in props ? props.event.title : '',
-	);
-	const [description, setDescription] = useState(
-		'event' in props ? props.event.description : '',
-	);
-	const [startDate, setStartDate] = useState(
-		dateToDateInputValue('event' in props ? props.event.startDate : new Date()),
-	);
-	const [startTime, setStartTime] = useState(
-		dateToTimeInputValue('event' in props ? props.event.startDate : new Date()),
-	);
-	const [eventType, setEventType] = useState<'point' | 'period'>(
-		'event' in props ? props.event.type : 'point',
-	);
-	const [hasEndDate, setHasEndDate] = useState(
-		'event' in props ? !!props.event.endDate : false,
-	);
-	const [endDate, setEndDate] = useState(
-		dateToDateInputValue(
-			'event' in props && props.event.endDate
-				? props.event.endDate
-				: new Date(),
-		),
-	);
-	const [endTime, setEndTime] = useState(
-		dateToTimeInputValue(
-			'event' in props && props.event.endDate
-				? props.event.endDate
-				: new Date(),
-		),
-	);
-	const [color, setColor] = useState(
-		'event' in props && props.event.color ? props.event.color : COLORS[0], // Default to indigo
-	);
-
 	const event = 'event' in props ? props.event : undefined;
-	const handleSave = () => {
-		if (!eventTitle || !startDate) return;
 
-		const startDateTime = new Date(`${startDate}T${startTime}`);
-		let endDateTime = hasEndDate
-			? new Date(`${endDate}T${endTime}`)
+	const { handleSubmit, register, reset, setValue, watch } =
+		useForm<EventFormValues>({
+			defaultValues: getDefaultValues(event),
+			mode: 'onChange',
+			resolver: zodResolver(eventFormSchema),
+		});
+
+	const eventType = watch('type');
+	const hasEndDate = watch('hasEndDate');
+	const color = watch('color');
+
+	useEffect(() => {
+		reset(getDefaultValues(event));
+	}, [event, reset]);
+
+	const handleSave = (values: EventFormValues) => {
+		const startDateTime = new Date(`${values.startDate}T${values.startTime}`);
+		let endDateTime = values.hasEndDate
+			? new Date(`${values.endDate}T${values.endTime}`)
 			: undefined;
 
-		// Ensure end date is after start date
 		if (endDateTime && endDateTime <= startDateTime) {
-			endDateTime = new Date(startDateTime.getTime() + 3_600_000); // Add 1 hour
+			endDateTime = new Date(startDateTime.getTime() + 3_600_000);
 		}
 
 		const newEvent: Event = {
 			...event,
-			color,
-			description: description || undefined,
+			color: values.color,
+			description: values.description || undefined,
 			endDate: endDateTime?.toISOString(),
 			id: event?.id || Date.now().toString(),
 			startDate: startDateTime.toISOString(),
-			title: eventTitle,
-			type: eventType,
+			title: values.title,
+			type: values.type,
 		};
 
 		onSave(newEvent);
@@ -118,180 +113,182 @@ export default function EventForm({
 				<DialogHeader>
 					<DialogTitle>{dialogTitle}</DialogTitle>
 				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					<div className="space-y-2">
-						<Label htmlFor="title">
-							<fbt desc="Label for an input to set an events title">Title</fbt>
-						</Label>
-						<Input
-							id="title"
-							onChange={(e) => setEventTitle(e.target.value)}
-							placeholder={fbt(
-								'e.g. Birth, Vaccination, Illness',
-								'Placeholder for event title input',
-							)}
-							value={eventTitle}
-						/>
-					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor="description">
-							<fbt desc="Label for an optional event description input">
-								Description (optional)
-							</fbt>
-						</Label>
-						<Textarea
-							id="description"
-							onChange={(e) => setDescription(e.target.value)}
-							placeholder={fbt(
-								'Additional details about the event',
-								'Placeholder for event description input',
-							)}
-							rows={3}
-							value={description}
-						/>
-					</div>
-
-					<div className="space-y-2">
-						<Label>
-							<fbt desc="Label for a radio input to set the events type (point or period)">
-								Event Type
-							</fbt>
-						</Label>
-						<RadioGroup
-							className="flex gap-4"
-							onValueChange={(value) =>
-								setEventType(value as 'point' | 'period')
-							}
-							value={eventType}
-						>
-							<div className="flex items-center space-x-2">
-								<RadioGroupItem
-									data-testid="point-event-radio"
-									id="point"
-									value="point"
-								/>
-								<Label htmlFor="point">
-									<fbt desc="Label for a radio input that sets the value to a point in time">
-										Point in time (e.g. Vaccination)
-									</fbt>
-								</Label>
-							</div>
-							<div className="flex items-center space-x-2">
-								<RadioGroupItem
-									data-testid="period-event-radio"
-									id="period"
-									value="period"
-								/>
-								<Label htmlFor="period">
-									<fbt desc="Label for a radio input that sets the value to a timne period">
-										Period (e.g. Illness)
-									</fbt>
-								</Label>
-							</div>
-						</RadioGroup>
-					</div>
-
-					<div className="grid grid-cols-2 gap-4">
+				<form onSubmit={handleSubmit(handleSave)}>
+					<div className="grid gap-4 py-4">
 						<div className="space-y-2">
-							<Label htmlFor="start-date">
-								<fbt common>Date</fbt>
+							<Label htmlFor="title">
+								<fbt desc="Label for an input to set an events title">
+									Title
+								</fbt>
 							</Label>
 							<Input
-								id="start-date"
-								onChange={(e) => setStartDate(e.target.value)}
-								type="date"
-								value={startDate}
+								id="title"
+								placeholder={fbt(
+									'e.g. Birth, Vaccination, Illness',
+									'Placeholder for event title input',
+								)}
+								{...register('title')}
 							/>
 						</div>
+
 						<div className="space-y-2">
-							<Label htmlFor="start-time">
-								<fbt common>Time</fbt>
+							<Label htmlFor="description">
+								<fbt desc="Label for an optional event description input">
+									Description (optional)
+								</fbt>
 							</Label>
-							<Input
-								id="start-time"
-								onChange={(e) => setStartTime(e.target.value)}
-								type="time"
-								value={startTime}
+							<Textarea
+								id="description"
+								placeholder={fbt(
+									'Additional details about the event',
+									'Placeholder for event description input',
+								)}
+								rows={3}
+								{...register('description')}
 							/>
 						</div>
-					</div>
 
-					{eventType === 'period' && (
-						<>
-							<div className="flex items-center space-x-2">
-								<Switch
-									checked={hasEndDate}
-									data-testid="has-end-date-switch"
-									id="has-end-date"
-									onCheckedChange={setHasEndDate}
-								/>
-								<Label htmlFor="has-end-date">
-									<fbt desc="Label for a switch that enables or disable the fields to set an end date for an event">
-										Set End Date
-									</fbt>
-								</Label>
-							</div>
-
-							{hasEndDate && (
-								<div className="grid grid-cols-2 gap-4">
-									<div className="space-y-2">
-										<Label htmlFor="end-date">
-											<fbt desc="Label for an input to set the end date of an event">
-												End Date
-											</fbt>
-										</Label>
-										<Input
-											id="end-date"
-											onChange={(e) => setEndDate(e.target.value)}
-											type="date"
-											value={endDate}
-										/>
-									</div>
-									<div className="space-y-2">
-										<Label htmlFor="end-time">
-											<fbt desc="Label for an input to set the end time of an event">
-												End Time
-											</fbt>
-										</Label>
-										<Input
-											id="end-time"
-											onChange={(e) => setEndTime(e.target.value)}
-											type="time"
-											value={endTime}
-										/>
-									</div>
+						<div className="space-y-2">
+							<Label>
+								<fbt desc="Label for a radio input to set the events type (point or period)">
+									Event Type
+								</fbt>
+							</Label>
+							<RadioGroup
+								className="flex gap-4"
+								onValueChange={(value) => {
+									setValue('type', value as 'point' | 'period', {
+										shouldValidate: true,
+									});
+								}}
+								value={eventType}
+							>
+								<div className="flex items-center space-x-2">
+									<RadioGroupItem
+										data-testid="point-event-radio"
+										id="point"
+										value="point"
+									/>
+									<Label htmlFor="point">
+										<fbt desc="Label for a radio input that sets the value to a point in time">
+											Point in time (e.g. Vaccination)
+										</fbt>
+									</Label>
 								</div>
-							)}
-						</>
-					)}
+								<div className="flex items-center space-x-2">
+									<RadioGroupItem
+										data-testid="period-event-radio"
+										id="period"
+										value="period"
+									/>
+									<Label htmlFor="period">
+										<fbt desc="Label for a radio input that sets the value to a timne period">
+											Period (e.g. Illness)
+										</fbt>
+									</Label>
+								</div>
+							</RadioGroup>
+						</div>
 
-					<div className="space-y-2">
-						<Label htmlFor="color">
-							<fbt desc="Label for color swatch picker">Color</fbt>
-						</Label>
-						<div className="flex gap-2">
-							{COLORS.map((colorOption) => (
-								<button
-									aria-label={`Farbe ${colorOption}`}
-									className={`w-8 h-8 rounded-full ${color === colorOption ? 'ring-2 ring-offset-2 ring-black' : ''}`}
-									key={colorOption}
-									onClick={() => setColor(colorOption)}
-									style={{ backgroundColor: colorOption }}
-									type="button"
-								/>
-							))}
+						<div className="grid grid-cols-2 gap-4">
+							<div className="space-y-2">
+								<Label htmlFor="start-date">
+									<fbt common>Date</fbt>
+								</Label>
+								<Input id="start-date" type="date" {...register('startDate')} />
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="start-time">
+									<fbt common>Time</fbt>
+								</Label>
+								<Input id="start-time" type="time" {...register('startTime')} />
+							</div>
+						</div>
+
+						{eventType === 'period' && (
+							<>
+								<div className="flex items-center space-x-2">
+									<Switch
+										checked={hasEndDate}
+										data-testid="has-end-date-switch"
+										id="has-end-date"
+										onCheckedChange={(checked) => {
+											setValue('hasEndDate', checked, {
+												shouldValidate: true,
+											});
+										}}
+									/>
+									<Label htmlFor="has-end-date">
+										<fbt desc="Label for a switch that enables or disable the fields to set an end date for an event">
+											Set End Date
+										</fbt>
+									</Label>
+								</div>
+
+								{hasEndDate && (
+									<div className="grid grid-cols-2 gap-4">
+										<div className="space-y-2">
+											<Label htmlFor="end-date">
+												<fbt desc="Label for an input to set the end date of an event">
+													End Date
+												</fbt>
+											</Label>
+											<Input
+												id="end-date"
+												type="date"
+												{...register('endDate')}
+											/>
+										</div>
+										<div className="space-y-2">
+											<Label htmlFor="end-time">
+												<fbt desc="Label for an input to set the end time of an event">
+													End Time
+												</fbt>
+											</Label>
+											<Input
+												id="end-time"
+												type="time"
+												{...register('endTime')}
+											/>
+										</div>
+									</div>
+								)}
+							</>
+						)}
+
+						<div className="space-y-2">
+							<Label htmlFor="color">
+								<fbt desc="Label for color swatch picker">Color</fbt>
+							</Label>
+							<div className="flex gap-2">
+								{COLORS.map((colorOption) => (
+									<button
+										aria-label={`Farbe ${colorOption}`}
+										className={`w-8 h-8 rounded-full ${
+											color === colorOption
+												? 'ring-2 ring-offset-2 ring-black'
+												: ''
+										}`}
+										key={colorOption}
+										onClick={() => {
+											setValue('color', colorOption, { shouldValidate: true });
+										}}
+										style={{ backgroundColor: colorOption }}
+										type="button"
+									/>
+								))}
+							</div>
 						</div>
 					</div>
-				</div>
-				<DialogFooter>
-					<Button onClick={onClose} variant="outline">
-						<fbt common>Cancel</fbt>
-					</Button>
-					<Button data-testid="save-button" onClick={handleSave} type="submit">
-						<fbt common>Save</fbt>
-					</Button>
-				</DialogFooter>
+					<DialogFooter>
+						<Button onClick={onClose} type="button" variant="outline">
+							<fbt common>Cancel</fbt>
+						</Button>
+						<Button data-testid="save-button" type="submit">
+							<fbt common>Save</fbt>
+						</Button>
+					</DialogFooter>
+				</form>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/app/feeding/components/feeding-form.test.tsx
+++ b/src/app/feeding/components/feeding-form.test.tsx
@@ -1,5 +1,11 @@
 import type { FeedingSession } from '@/types/feeding';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import FeedingForm from './feeding-form';
 
@@ -21,7 +27,7 @@ describe('FeedingForm', () => {
 		cleanup();
 	});
 
-	it('renders with initial data and calls onSave when submitted', () => {
+	it('renders with initial data and calls onSave when submitted', async () => {
 		const initialFeeding: FeedingSession = {
 			breast: 'left',
 			durationInSeconds: 600, // 10 minutes
@@ -39,14 +45,14 @@ describe('FeedingForm', () => {
 		const saveButton = screen.getByTestId('save-button');
 		fireEvent.click(saveButton);
 
-		expect(mockOnSave).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(mockOnSave).toHaveBeenCalledTimes(1));
 		const savedSession = mockOnSave.mock.calls[0][0];
 		expect(savedSession.breast).toBe('left');
 		expect(savedSession.durationInSeconds).toBe(600);
 		expect(savedSession.id).toBe('1');
 	});
 
-	it('renders without initial data and allows saving new session', () => {
+	it('renders without initial data and allows saving new session', async () => {
 		render(<FeedingForm {...baseProps} />);
 
 		// Default should be left breast
@@ -59,7 +65,7 @@ describe('FeedingForm', () => {
 
 		fireEvent.click(screen.getByTestId('save-button'));
 
-		expect(mockOnSave).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(mockOnSave).toHaveBeenCalledTimes(1));
 		const savedSession = mockOnSave.mock.calls[0][0];
 		expect(savedSession.breast).toBe('right');
 		expect(savedSession.durationInSeconds).toBe(900);

--- a/src/app/feeding/components/feeding-form.tsx
+++ b/src/app/feeding/components/feeding-form.tsx
@@ -1,5 +1,8 @@
-import type { FeedingSession } from '@/types/feeding';
-import { ReactNode, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { FeedingFormValues, FeedingSession } from '@/types/feeding';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -11,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { feedingFormSchema } from '@/types/feeding';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
 import { dateToTimeInputValue } from '@/utils/date-to-time-input-value';
 
@@ -21,49 +25,42 @@ interface FeedingFormProps {
 	title: ReactNode;
 }
 
+function getDefaultValues(
+	feeding: FeedingSession | undefined,
+): FeedingFormValues {
+	return {
+		breast: feeding?.breast ?? 'left',
+		date: dateToDateInputValue(feeding?.startTime ?? new Date()),
+		duration: feeding?.durationInSeconds
+			? Math.round(feeding.durationInSeconds / 60).toString()
+			: '',
+		time: dateToTimeInputValue(feeding?.startTime ?? new Date()),
+	};
+}
+
 export default function FeedingForm({
 	feeding,
 	onClose,
 	onSave,
 	title,
 }: FeedingFormProps) {
-	const [breast, setBreast] = useState<'left' | 'right'>(
-		feeding?.breast ?? 'left',
-	);
-	const [date, setDate] = useState(
-		dateToDateInputValue(feeding?.startTime ?? new Date()),
-	);
-	const [time, setTime] = useState(
-		dateToTimeInputValue(feeding?.startTime ?? new Date()),
-	);
-	const [duration, setDuration] = useState(
-		feeding?.durationInSeconds
-			? Math.round(feeding.durationInSeconds / 60).toString()
-			: '',
-	);
+	const { handleSubmit, register, reset, setValue, watch } =
+		useForm<FeedingFormValues>({
+			defaultValues: getDefaultValues(feeding),
+			mode: 'onChange',
+			resolver: zodResolver(feedingFormSchema),
+		});
+
+	const breast = watch('breast');
 
 	useEffect(() => {
-		if (!feeding) {
-			return;
-		}
+		reset(getDefaultValues(feeding));
+	}, [feeding, reset]);
 
-		const startDate = new Date(feeding.startTime);
-
-		setDate(dateToDateInputValue(startDate));
-		setTime(dateToTimeInputValue(startDate));
-
-		const durationInMinutes = Math.round(feeding.durationInSeconds / 60);
-		setDuration(durationInMinutes.toString());
-	}, [feeding]);
-
-	const handleSubmit = () => {
-		if (!date || !time || !duration || Number.isNaN(Number(duration))) {
-			return;
-		}
-
-		const durationInMinutes = Number(duration);
-		const [year, month, day] = date.split('-').map(Number);
-		const [hours, minutes] = time.split(':').map(Number);
+	const handleSave = (values: FeedingFormValues) => {
+		const durationInMinutes = Number(values.duration);
+		const [year, month, day] = values.date.split('-').map(Number);
+		const [hours, minutes] = values.time.split(':').map(Number);
 
 		const startTime = new Date(year, month - 1, day, hours, minutes);
 		const endTime = new Date(
@@ -72,7 +69,7 @@ export default function FeedingForm({
 
 		const updatedSession: FeedingSession = {
 			...feeding,
-			breast,
+			breast: values.breast,
 			durationInSeconds: durationInMinutes * 60,
 			endTime: endTime.toISOString(),
 			id: feeding?.id ?? Date.now().toString(),
@@ -89,106 +86,103 @@ export default function FeedingForm({
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>
 				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					<div className="space-y-2">
-						<Label>
-							<fbt desc="Label for a radio group that allows the user to select which breat was used to feed">
-								Breast
-							</fbt>
-						</Label>
-						<RadioGroup
-							className="flex gap-4"
-							onValueChange={(value) => setBreast(value as 'left' | 'right')}
-							value={breast}
-						>
-							<div className="flex items-center space-x-2">
-								<RadioGroupItem
-									className="text-left-breast border-left-breast"
-									data-testid="left-breast-radio"
-									id="edit-left"
-									value="left"
-								/>
-								<Label className="text-left-breast-dark" htmlFor="edit-left">
-									<fbt desc="Label for a radio button that indicates the left breast was used to feed">
-										Left Breast
-									</fbt>
-								</Label>
-							</div>
-							<div className="flex items-center space-x-2">
-								<RadioGroupItem
-									className="text-right-breast border-right-breast"
-									data-testid="right-breast-radio"
-									id="edit-right"
-									value="right"
-								/>
-								<Label className="text-right-breast-dark" htmlFor="edit-right">
-									<fbt desc="Label for a radio button that indicates the right breast was used to feed">
-										Right Breast
-									</fbt>
-								</Label>
-							</div>
-						</RadioGroup>
-					</div>
-
-					<div className="grid grid-cols-2 gap-4">
+				<form onSubmit={handleSubmit(handleSave)}>
+					<div className="grid gap-4 py-4">
 						<div className="space-y-2">
-							<Label htmlFor="edit-date">
-								<fbt desc="Label for a date input">Date</fbt>
+							<Label>
+								<fbt desc="Label for a radio group that allows the user to select which breat was used to feed">
+									Breast
+								</fbt>
 							</Label>
-							<Input
-								id="edit-date"
-								onChange={(e) => setDate(e.target.value)}
-								type="date"
-								value={date}
-							/>
+							<RadioGroup
+								className="flex gap-4"
+								onValueChange={(value) => {
+									setValue('breast', value as 'left' | 'right', {
+										shouldValidate: true,
+									});
+								}}
+								value={breast}
+							>
+								<div className="flex items-center space-x-2">
+									<RadioGroupItem
+										className="text-left-breast border-left-breast"
+										data-testid="left-breast-radio"
+										id="edit-left"
+										value="left"
+									/>
+									<Label className="text-left-breast-dark" htmlFor="edit-left">
+										<fbt desc="Label for a radio button that indicates the left breast was used to feed">
+											Left Breast
+										</fbt>
+									</Label>
+								</div>
+								<div className="flex items-center space-x-2">
+									<RadioGroupItem
+										className="text-right-breast border-right-breast"
+										data-testid="right-breast-radio"
+										id="edit-right"
+										value="right"
+									/>
+									<Label
+										className="text-right-breast-dark"
+										htmlFor="edit-right"
+									>
+										<fbt desc="Label for a radio button that indicates the right breast was used to feed">
+											Right Breast
+										</fbt>
+									</Label>
+								</div>
+							</RadioGroup>
 						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<div className="space-y-2">
+								<Label htmlFor="edit-date">
+									<fbt desc="Label for a date input">Date</fbt>
+								</Label>
+								<Input id="edit-date" type="date" {...register('date')} />
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="edit-time">
+									<fbt desc="Label for a time input that sets the starting time of a feeding session">
+										Start Time
+									</fbt>
+								</Label>
+								<Input id="edit-time" type="time" {...register('time')} />
+							</div>
+						</div>
+
 						<div className="space-y-2">
-							<Label htmlFor="edit-time">
-								<fbt desc="Label for a time input that sets the starting time of a feeding session">
-									Start Time
+							<Label htmlFor="edit-duration">
+								<fbt desc="Label for a number input that sets the duration of a feeding session in minutes">
+									Duration (minutes)
 								</fbt>
 							</Label>
 							<Input
-								id="edit-time"
-								onChange={(e) => setTime(e.target.value)}
-								type="time"
-								value={time}
+								id="edit-duration"
+								min="1"
+								type="number"
+								{...register('duration')}
 							/>
 						</div>
 					</div>
-
-					<div className="space-y-2">
-						<Label htmlFor="edit-duration">
-							<fbt desc="Label for a number input that sets the duration of a feeding session in minutes">
-								Duration (minutes)
-							</fbt>
-						</Label>
-						<Input
-							id="edit-duration"
-							min="1"
-							onChange={(e) => setDuration(e.target.value)}
-							type="number"
-							value={duration}
-						/>
-					</div>
-				</div>
-				<DialogFooter>
-					<Button onClick={onClose} variant="outline">
-						<fbt common>Cancel</fbt>
-					</Button>
-					<Button
-						className={
-							breast === 'left'
-								? 'bg-left-breast hover:bg-left-breast-dark'
-								: 'bg-right-breast hover:bg-right-breast-dark'
-						}
-						data-testid="save-button"
-						onClick={handleSubmit}
-						type="submit"
-					>
-						<fbt common>Save</fbt>
-					</Button>
-				</DialogFooter>
+					<DialogFooter>
+						<Button onClick={onClose} type="button" variant="outline">
+							<fbt common>Cancel</fbt>
+						</Button>
+						<Button
+							className={
+								breast === 'left'
+									? 'bg-left-breast hover:bg-left-breast-dark'
+									: 'bg-right-breast hover:bg-right-breast-dark'
+							}
+							data-testid="save-button"
+							type="submit"
+						>
+							<fbt common>Save</fbt>
+						</Button>
+					</DialogFooter>
+				</form>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/app/growth/components/growth-form.tsx
+++ b/src/app/growth/components/growth-form.tsx
@@ -1,6 +1,9 @@
-import type { GrowthMeasurement } from '@/types/growth';
+import type { ReactNode } from 'react';
+import type { GrowthFormValues, GrowthMeasurement } from '@/types/growth';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
-import { ReactNode, useState } from 'react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -12,24 +15,35 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { growthFormSchema } from '@/types/growth';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
 
 interface EditGrowthFormProps {
 	measurement: GrowthMeasurement;
 	onClose: () => void;
-	// Optional for editing existing measurement
 	onSave: (measurement: GrowthMeasurement) => void;
 	title: ReactNode;
 }
 
 interface AddGrowthFormProps {
 	onClose: () => void;
-	// Optional for editing existing measurement
 	onSave: (measurement: GrowthMeasurement) => void;
 	title: ReactNode;
 }
 
 type MeasurementFormProps = EditGrowthFormProps | AddGrowthFormProps;
+
+function getDefaultValues(
+	measurement: GrowthMeasurement | undefined,
+): GrowthFormValues {
+	return {
+		date: dateToDateInputValue(measurement?.date ?? new Date()),
+		headCircumference: measurement?.headCircumference?.toString() ?? '',
+		height: measurement?.height?.toString() ?? '',
+		notes: measurement?.notes ?? '',
+		weight: measurement?.weight?.toString() ?? '',
+	};
+}
 
 export default function MeasurementForm({
 	onClose,
@@ -37,55 +51,34 @@ export default function MeasurementForm({
 	title,
 	...props
 }: MeasurementFormProps) {
-	const [date, setDate] = useState(
-		dateToDateInputValue(
-			'measurement' in props ? props.measurement.date : new Date(),
-		),
-	);
-	const [weight, setWeight] = useState(
-		'measurement' in props ? props.measurement.weight?.toString() : '',
-	);
-	const [height, setHeight] = useState(
-		'measurement' in props ? props.measurement.height?.toString() : '',
-	);
-	const [headCircumference, setHeadCircumference] = useState(
-		'measurement' in props
-			? props.measurement.headCircumference?.toString()
-			: '',
-	);
-	const [notes, setNotes] = useState(
-		'measurement' in props ? props.measurement.notes : '',
-	);
-	const [error, setError] = useState('');
+	const measurement = 'measurement' in props ? props.measurement : undefined;
 
-	const handleSave = () => {
-		// Validate that at least one of weight or height is provided
-		if (!weight && !height && !headCircumference) {
-			setError(
-				fbt(
-					'Please enter at least a weight, height, or head circumference.',
-					'Message shown when no weight, height, or head circumference is provided. At least one is required',
-				),
-			);
-			return;
-		}
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+		reset,
+	} = useForm<GrowthFormValues>({
+		defaultValues: getDefaultValues(measurement),
+		mode: 'onChange',
+		resolver: zodResolver(growthFormSchema),
+	});
 
-		setError('');
+	useEffect(() => {
+		reset(getDefaultValues(measurement));
+	}, [measurement, reset]);
 
-		const measurement = 'measurement' in props ? props.measurement : undefined;
-
+	const handleSave = (values: GrowthFormValues) => {
 		const newMeasurement: GrowthMeasurement = {
 			...measurement,
-			date: new Date(`${date}T12:00:00`).toISOString(),
-			headCircumference: headCircumference
-				? Number.parseFloat(headCircumference)
+			date: new Date(`${values.date}T12:00:00`).toISOString(),
+			headCircumference: values.headCircumference
+				? Number.parseFloat(values.headCircumference)
 				: undefined,
-			height: height ? Number.parseFloat(height) : undefined,
+			height: values.height ? Number.parseFloat(values.height) : undefined,
 			id: measurement?.id || Date.now().toString(),
-
-			notes: notes || undefined,
-			// Use noon to avoid timezone issues
-			weight: weight ? Number.parseFloat(weight) : undefined,
+			notes: values.notes || undefined,
+			weight: values.weight ? Number.parseFloat(values.weight) : undefined,
 		};
 
 		onSave(newMeasurement);
@@ -98,93 +91,95 @@ export default function MeasurementForm({
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>
 				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					<div className="space-y-2">
-						<Label htmlFor="date">
-							<fbt common>Date</fbt>
-						</Label>
-						<Input
-							id="date"
-							onChange={(e) => setDate(e.target.value)}
-							type="date"
-							value={date}
-						/>
-					</div>
+				<form onSubmit={handleSubmit(handleSave)}>
+					<div className="grid gap-4 py-4">
+						<div className="space-y-2">
+							<Label htmlFor="date">
+								<fbt common>Date</fbt>
+							</Label>
+							<Input id="date" type="date" {...register('date')} />
+						</div>
 
-					<div className="grid grid-cols-1 gap-4">
-						<div className="space-y-2">
-							<Label htmlFor="weight">
-								<fbt desc="Label for a body weight input">Weight (g)</fbt>
-							</Label>
-							<Input
-								id="weight"
-								onChange={(e) => setWeight(e.target.value)}
-								placeholder={fbt('e.g. 3500', 'Placeholder for a weight input')}
-								type="number"
-								value={weight}
-							/>
+						<div className="grid grid-cols-1 gap-4">
+							<div className="space-y-2">
+								<Label htmlFor="weight">
+									<fbt desc="Label for a body weight input">Weight (g)</fbt>
+								</Label>
+								<Input
+									id="weight"
+									placeholder={fbt(
+										'e.g. 3500',
+										'Placeholder for a weight input',
+									)}
+									type="number"
+									{...register('weight')}
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="height">
+									<fbt desc="Label for a body height input">Height (cm)</fbt>
+								</Label>
+								<Input
+									id="height"
+									placeholder={fbt('e.g. 50', 'Placeholder for a height input')}
+									step="0.1"
+									type="number"
+									{...register('height')}
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="headCircumference">
+									<fbt desc="Label for a head circumference input">
+										Head Circumference (cm)
+									</fbt>
+								</Label>
+								<Input
+									id="headCircumference"
+									placeholder={fbt(
+										'e.g. 35',
+										'Placeholder for a head circumference input',
+									)}
+									step="0.1"
+									type="number"
+									{...register('headCircumference')}
+								/>
+							</div>
 						</div>
+
+						{errors.weight && (
+							<div className="text-sm text-red-500">
+								<fbt desc="Message shown when no weight, height, or head circumference is provided. At least one is required">
+									Please enter at least a weight, height, or head circumference.
+								</fbt>
+							</div>
+						)}
+
 						<div className="space-y-2">
-							<Label htmlFor="height">
-								<fbt desc="Label for a body height input">Height (cm)</fbt>
-							</Label>
-							<Input
-								id="height"
-								onChange={(e) => setHeight(e.target.value)}
-								placeholder={fbt('e.g. 50', 'Placeholder for a height input')}
-								step="0.1"
-								type="number"
-								value={height}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="headCircumference">
-								<fbt desc="Label for a head circumference input">
-									Head Circumference (cm)
+							<Label htmlFor="notes">
+								<fbt desc="Label for an optional notes textarea">
+									Notes (optional)
 								</fbt>
 							</Label>
-							<Input
-								id="headCircumference"
-								onChange={(e) => setHeadCircumference(e.target.value)}
+							<Textarea
+								id="notes"
 								placeholder={fbt(
-									'e.g. 35',
-									'Placeholder for a head circumference input',
+									'Additional information',
+									'Placeholder for a text input for notes',
 								)}
-								step="0.1"
-								type="number"
-								value={headCircumference}
+								rows={3}
+								{...register('notes')}
 							/>
 						</div>
 					</div>
-
-					{error && <div className="text-sm text-red-500">{error}</div>}
-
-					<div className="space-y-2">
-						<Label htmlFor="notes">
-							<fbt desc="Label for an optional notes textarea">
-								Notes (optional)
-							</fbt>
-						</Label>
-						<Textarea
-							id="notes"
-							onChange={(e) => setNotes(e.target.value)}
-							placeholder={fbt(
-								'Additional information',
-								'Placeholder for a text input for notes',
-							)}
-							rows={3}
-							value={notes}
-						/>
-					</div>
-				</div>
-				<DialogFooter>
-					<Button onClick={onClose} variant="outline">
-						<fbt common>Cancel</fbt>
-					</Button>
-					<Button onClick={handleSave} type="submit">
-						<fbt common>Save</fbt>
-					</Button>
-				</DialogFooter>
+					<DialogFooter>
+						<Button onClick={onClose} type="button" variant="outline">
+							<fbt common>Cancel</fbt>
+						</Button>
+						<Button type="submit">
+							<fbt common>Save</fbt>
+						</Button>
+					</DialogFooter>
+				</form>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/app/growth/components/teething-form.tsx
+++ b/src/app/growth/components/teething-form.tsx
@@ -1,6 +1,8 @@
-import type { Tooth } from '@/types/teething';
+import type { TeethingFormValues, Tooth } from '@/types/teething';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
-import { useState } from 'react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -12,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { teethingFormSchema } from '@/types/teething';
 import { dateToDateInputValue } from '@/utils/date-to-date-input-value';
 
 interface TeethingFormProps {
@@ -21,22 +24,34 @@ interface TeethingFormProps {
 	toothName: string;
 }
 
+function getDefaultValues(tooth: Tooth): TeethingFormValues {
+	return {
+		date: dateToDateInputValue(tooth.date ? new Date(tooth.date) : new Date()),
+		notes: tooth.notes ?? '',
+	};
+}
+
 export default function TeethingForm({
 	onClose,
 	onSave,
 	tooth,
 	toothName,
 }: TeethingFormProps) {
-	const [date, setDate] = useState(
-		dateToDateInputValue(tooth.date ? new Date(tooth.date) : new Date()),
-	);
-	const [notes, setNotes] = useState(tooth.notes || '');
+	const { handleSubmit, register, reset } = useForm<TeethingFormValues>({
+		defaultValues: getDefaultValues(tooth),
+		mode: 'onChange',
+		resolver: zodResolver(teethingFormSchema),
+	});
 
-	const handleSave = () => {
+	useEffect(() => {
+		reset(getDefaultValues(tooth));
+	}, [reset, tooth]);
+
+	const handleSave = (values: TeethingFormValues) => {
 		onSave({
 			...tooth,
-			date: new Date(`${date}T12:00:00`).toISOString(),
-			notes: notes || undefined,
+			date: new Date(`${values.date}T12:00:00`).toISOString(),
+			notes: values.notes || undefined,
 		});
 		onClose();
 	};
@@ -57,48 +72,43 @@ export default function TeethingForm({
 					<DialogTitle>
 						<fbt desc="Edit teething progress title">
 							Edit Teething: <fbt:param name="toothName">{toothName}</fbt:param>{' '}
-							(
-							<fbt:param name="fdi">{tooth.toothId}</fbt:param>)
+							(<fbt:param name="fdi">{tooth.toothId}</fbt:param>)
 						</fbt>
 					</DialogTitle>
 				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					<div className="space-y-2">
-						<Label htmlFor="date">
-							<fbt desc="Date of eruption">Eruption Date</fbt>
-						</Label>
-						<Input
-							id="date"
-							onChange={(e) => setDate(e.target.value)}
-							type="date"
-							value={date}
-						/>
-					</div>
+				<form onSubmit={handleSubmit(handleSave)}>
+					<div className="grid gap-4 py-4">
+						<div className="space-y-2">
+							<Label htmlFor="date">
+								<fbt desc="Date of eruption">Eruption Date</fbt>
+							</Label>
+							<Input id="date" type="date" {...register('date')} />
+						</div>
 
-					<div className="space-y-2">
-						<Label htmlFor="notes">
-							<fbt common>Notes</fbt>
-						</Label>
-						<Textarea
-							id="notes"
-							onChange={(e) => setNotes(e.target.value)}
-							placeholder={fbt(
-								'Additional information',
-								'Placeholder for a text input for notes',
-							)}
-							rows={3}
-							value={notes}
-						/>
+						<div className="space-y-2">
+							<Label htmlFor="notes">
+								<fbt common>Notes</fbt>
+							</Label>
+							<Textarea
+								id="notes"
+								placeholder={fbt(
+									'Additional information',
+									'Placeholder for a text input for notes',
+								)}
+								rows={3}
+								{...register('notes')}
+							/>
+						</div>
 					</div>
-				</div>
-				<DialogFooter className="flex justify-between sm:justify-between">
-					<Button onClick={handleClear} variant="outline">
-						<fbt desc="Clear teething data">Clear</fbt>
-					</Button>
-					<Button onClick={handleSave} type="submit">
-						<fbt common>Save</fbt>
-					</Button>
-				</DialogFooter>
+					<DialogFooter className="flex justify-between sm:justify-between">
+						<Button onClick={handleClear} type="button" variant="outline">
+							<fbt desc="Clear teething data">Clear</fbt>
+						</Button>
+						<Button type="submit">
+							<fbt common>Save</fbt>
+						</Button>
+					</DialogFooter>
+				</form>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/components/product-form.tsx
+++ b/src/components/product-form.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import type { DiaperProduct, DiaperProductFormValues } from '@/types/diaper';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
-import { useState } from 'react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { DiaperProduct } from '@/types/diaper';
+import { diaperProductSchema } from '@/types/diaper';
 
 interface ProductFormProps {
 	initialData?: Partial<DiaperProduct>;
@@ -14,49 +17,66 @@ interface ProductFormProps {
 	onSave: (data: DiaperProduct) => void;
 }
 
+function getDefaultValues(
+	initialData: Partial<DiaperProduct> | undefined,
+): DiaperProductFormValues {
+	return {
+		costPerDiaper: initialData?.costPerDiaper?.toString() ?? '',
+		isReusable: initialData?.isReusable ?? false,
+		name: initialData?.name ?? '',
+	};
+}
+
 export default function ProductForm({
 	initialData,
 	onCancel,
 	onSave,
 }: ProductFormProps) {
-	const [name, setName] = useState(initialData?.name || '');
-	const [costPerDiaper, setCostPerDiaper] = useState(
-		initialData?.costPerDiaper?.toString() || '',
-	);
-	const [isReusable, setIsReusable] = useState(
-		initialData?.isReusable || false,
-	);
+	const {
+		formState: { isValid },
+		handleSubmit,
+		register,
+		reset,
+		setValue,
+		watch,
+	} = useForm<DiaperProductFormValues>({
+		defaultValues: getDefaultValues(initialData),
+		mode: 'onChange',
+		resolver: zodResolver(diaperProductSchema),
+	});
 
-	const handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!name) return;
+	const isReusable = watch('isReusable');
 
+	useEffect(() => {
+		reset(getDefaultValues(initialData));
+	}, [initialData, reset]);
+
+	const handleSave = (values: DiaperProductFormValues) => {
 		onSave({
 			...(initialData as DiaperProduct),
-			costPerDiaper: costPerDiaper
-				? Number.parseFloat(costPerDiaper)
+			costPerDiaper: values.costPerDiaper
+				? Number.parseFloat(values.costPerDiaper)
 				: undefined,
-			id: initialData?.id || crypto.randomUUID(),
-			isReusable,
-			name,
+			id: initialData?.id ?? crypto.randomUUID(),
+			isReusable: values.isReusable,
+			name: values.name,
 		});
 	};
 
 	return (
-		<form className="space-y-4 pt-4" onSubmit={handleSubmit}>
+		<form className="space-y-4 pt-4" onSubmit={handleSubmit(handleSave)}>
 			<div className="space-y-2">
 				<Label htmlFor="product-name">
 					<fbt desc="Label for product name input">Product Name</fbt>
 				</Label>
 				<Input
 					id="product-name"
-					onChange={(e) => setName(e.target.value)}
 					placeholder={fbt(
 						'e.g. Pampers Size 1',
 						'Placeholder for product name',
 					)}
 					required
-					value={name}
+					{...register('name')}
 				/>
 			</div>
 
@@ -66,11 +86,10 @@ export default function ProductForm({
 				</Label>
 				<Input
 					id="product-cost"
-					onChange={(e) => setCostPerDiaper(e.target.value)}
 					placeholder="0.00"
 					step="0.01"
 					type="number"
-					value={costPerDiaper}
+					{...register('costPerDiaper')}
 				/>
 			</div>
 
@@ -78,7 +97,9 @@ export default function ProductForm({
 				<Switch
 					checked={isReusable}
 					id="product-reusable"
-					onCheckedChange={setIsReusable}
+					onCheckedChange={(checked) => {
+						setValue('isReusable', checked, { shouldValidate: true });
+					}}
 				/>
 				<Label htmlFor="product-reusable">
 					<fbt desc="Label for reusable diaper switch">Reusable Diaper</fbt>
@@ -89,7 +110,7 @@ export default function ProductForm({
 				<Button onClick={onCancel} type="button" variant="outline">
 					<fbt common>Cancel</fbt>
 				</Button>
-				<Button type="submit">
+				<Button disabled={!isValid} type="submit">
 					<fbt common>Save</fbt>
 				</Button>
 			</div>

--- a/src/components/profile-form.tsx
+++ b/src/components/profile-form.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import type { Profile, ProfileFormValues, Sex } from '@/types/profile';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { fbt } from 'fbtee';
 import { Check } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -13,7 +16,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/ui/select';
-import { Profile, Sex } from '@/types/profile';
+import { profileFormSchema } from '@/types/profile';
 
 interface ProfileFormProps {
 	initialData?: Profile | null;
@@ -47,37 +50,54 @@ const COLORS = [
 	'bg-rose-500',
 ];
 
+function getDefaultValues(
+	initialData: Profile | null | undefined,
+	fallbackColor: string,
+): ProfileFormValues {
+	return {
+		color: initialData?.color ?? fallbackColor,
+		dob: initialData?.dob ?? '',
+		name: initialData?.name ?? '',
+		sex: initialData?.sex ?? 'boy',
+	};
+}
+
 export default function ProfileForm({
 	initialData,
 	onOptOut,
 	onSave,
 }: ProfileFormProps) {
-	const [dob, setDob] = useState(initialData?.dob || '');
-	const [sex, setSex] = useState<Sex | ''>(initialData?.sex || '');
-	const [name, setName] = useState(initialData?.name || '');
-	const [color, setColor] = useState(
-		initialData?.color || COLORS[Math.floor(Math.random() * COLORS.length)],
+	const fallbackColor = useMemo(
+		() => COLORS[Math.floor(Math.random() * COLORS.length)],
+		[],
 	);
 
-	useEffect(() => {
-		if (initialData) {
-			setDob(initialData.dob || '');
-			setSex(initialData.sex || '');
-			setName(initialData.name || '');
-			if (initialData.color) {
-				setColor(initialData.color);
-			}
-		}
-	}, [initialData]);
+	const {
+		formState: { isValid },
+		handleSubmit,
+		register,
+		reset,
+		setValue,
+		watch,
+	} = useForm<ProfileFormValues>({
+		defaultValues: getDefaultValues(initialData, fallbackColor),
+		mode: 'onChange',
+		resolver: zodResolver(profileFormSchema),
+	});
 
-	const handleSave = () => {
-		if (dob && sex && name) {
-			onSave({ color, dob, name, sex });
-		}
+	const color = watch('color');
+	const sex = watch('sex');
+
+	useEffect(() => {
+		reset(getDefaultValues(initialData, fallbackColor));
+	}, [fallbackColor, initialData, reset]);
+
+	const handleSave = (values: ProfileFormValues) => {
+		onSave(values);
 	};
 
 	return (
-		<div className="space-y-6 py-4">
+		<form className="space-y-6 py-4" onSubmit={handleSubmit(handleSave)}>
 			<div className="space-y-4">
 				<div className="space-y-2">
 					<Label htmlFor="name">
@@ -85,22 +105,16 @@ export default function ProfileForm({
 					</Label>
 					<Input
 						id="name"
-						onChange={(e) => setName(e.target.value)}
 						placeholder={fbt('Name', 'Placeholder for child name input')}
 						type="text"
-						value={name}
+						{...register('name')}
 					/>
 				</div>
 				<div className="space-y-2">
 					<Label htmlFor="dob">
 						<fbt desc="Label for date of birth input">Date of Birth</fbt>
 					</Label>
-					<Input
-						id="dob"
-						onChange={(e) => setDob(e.target.value)}
-						type="date"
-						value={dob}
-					/>
+					<Input id="dob" type="date" {...register('dob')} />
 				</div>
 				<div className="space-y-2">
 					<Label htmlFor="sex">
@@ -108,9 +122,7 @@ export default function ProfileForm({
 					</Label>
 					<Select
 						onValueChange={(value) => {
-							if (value) {
-								setSex(value as Sex);
-							}
+							setValue('sex', value as Sex, { shouldValidate: true });
 						}}
 						value={sex}
 					>
@@ -136,18 +148,22 @@ export default function ProfileForm({
 						<fbt desc="Label for color selection">Color</fbt>
 					</Label>
 					<div className="flex flex-wrap gap-2">
-						{COLORS.map((c) => (
+						{COLORS.map((colorOption) => (
 							<button
-								className={`flex h-8 w-8 items-center justify-center rounded-full border-2 transition-all ${c} ${
-									color === c
+								className={`flex h-8 w-8 items-center justify-center rounded-full border-2 transition-all ${colorOption} ${
+									color === colorOption
 										? 'border-slate-900 scale-110'
 										: 'border-transparent hover:scale-105'
 								}`}
-								key={c}
-								onClick={() => setColor(c)}
+								key={colorOption}
+								onClick={() => {
+									setValue('color', colorOption, { shouldValidate: true });
+								}}
 								type="button"
 							>
-								{color === c && <Check className="h-4 w-4 text-white" />}
+								{color === colorOption && (
+									<Check className="h-4 w-4 text-white" />
+								)}
 							</button>
 						))}
 					</div>
@@ -155,17 +171,14 @@ export default function ProfileForm({
 			</div>
 
 			<div className="flex flex-col gap-2 pt-4">
-				<Button
-					className="w-full"
-					disabled={!dob || !sex || !name}
-					onClick={handleSave}
-				>
+				<Button className="w-full" disabled={!isValid} type="submit">
 					<fbt desc="Button to save profile information">Save Profile</fbt>
 				</Button>
 				<Button
 					className="w-full text-muted-foreground text-xs"
 					data-testid="profile-opt-out-button"
 					onClick={onOptOut}
+					type="button"
 					variant="ghost"
 				>
 					<fbt desc="Button to opt out of providing profile information">
@@ -173,6 +186,6 @@ export default function ProfileForm({
 					</fbt>
 				</Button>
 			</div>
-		</div>
+		</form>
 	);
 }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,18 +2,22 @@ import { Input as InputPrimitive } from '@base-ui/react/input';
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-	return (
-		<InputPrimitive
-			type={type}
-			data-slot="input"
-			className={cn(
-				'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+	({ className, type, ...props }, ref) => {
+		return (
+			<InputPrimitive
+				type={type}
+				data-slot="input"
+				ref={ref}
+				className={cn(
+					'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+					className,
+				)}
+				{...props}
+			/>
+		);
+	},
+);
+Input.displayName = 'Input';
 
 export { Input };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+const Textarea = React.forwardRef<
+	HTMLTextAreaElement,
+	React.ComponentProps<'textarea'>
+>(({ className, ...props }, ref) => {
 	return (
 		<textarea
 			data-slot="textarea"
@@ -9,9 +12,11 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
 				'border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50',
 				className,
 			)}
+			ref={ref}
 			{...props}
 		/>
 	);
-}
+});
+Textarea.displayName = 'Textarea';
 
 export { Textarea };

--- a/src/types/diaper.ts
+++ b/src/types/diaper.ts
@@ -1,4 +1,50 @@
 import type { BaseEntity } from './base-entity';
+import { z } from 'zod';
+
+export const diaperFormSchema = z.object({
+	containsStool: z.boolean(),
+	containsUrine: z.boolean(),
+	date: z.string().min(1),
+	diaperProductId: z.string().optional(),
+	leakage: z.boolean(),
+	notes: z.string().optional(),
+	pottyStool: z.boolean(),
+	pottyUrine: z.boolean(),
+	temperature: z
+		.string()
+		.optional()
+		.refine(
+			(value) =>
+				value === undefined ||
+				value.length === 0 ||
+				!Number.isNaN(Number(value)),
+			{
+				message: 'Temperature must be a number',
+			},
+		),
+	time: z.string().min(1),
+});
+
+export type DiaperFormValues = z.infer<typeof diaperFormSchema>;
+
+export const diaperProductSchema = z.object({
+	costPerDiaper: z
+		.string()
+		.optional()
+		.refine(
+			(value) =>
+				value === undefined ||
+				value.length === 0 ||
+				!Number.isNaN(Number(value)),
+			{
+				message: 'Cost per diaper must be a number',
+			},
+		),
+	isReusable: z.boolean(),
+	name: z.string().min(1),
+});
+
+export type DiaperProductFormValues = z.infer<typeof diaperProductSchema>;
 
 export interface DiaperProduct extends BaseEntity {
 	/** Whether the product is archived. */

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,4 +1,19 @@
 import type { BaseEntity } from './base-entity';
+import { z } from 'zod';
+
+export const eventFormSchema = z.object({
+	color: z.string().min(1),
+	description: z.string(),
+	endDate: z.string(),
+	endTime: z.string(),
+	hasEndDate: z.boolean(),
+	startDate: z.string().min(1),
+	startTime: z.string().min(1),
+	title: z.string().min(1),
+	type: z.enum(['point', 'period']),
+});
+
+export type EventFormValues = z.infer<typeof eventFormSchema>;
 
 export interface Event extends BaseEntity {
 	// point = single date, period = start to end date

--- a/src/types/feeding.ts
+++ b/src/types/feeding.ts
@@ -1,4 +1,19 @@
 import type { BaseEntity } from './base-entity';
+import { z } from 'zod';
+
+export const feedingFormSchema = z.object({
+	breast: z.enum(['left', 'right']),
+	date: z.string().min(1),
+	duration: z
+		.string()
+		.min(1)
+		.refine((value) => !Number.isNaN(Number(value)), {
+			message: 'Duration must be a number',
+		}),
+	time: z.string().min(1),
+});
+
+export type FeedingFormValues = z.infer<typeof feedingFormSchema>;
 
 export interface FeedingSession extends BaseEntity {
 	breast: 'left' | 'right';

--- a/src/types/growth.ts
+++ b/src/types/growth.ts
@@ -1,4 +1,26 @@
 import type { BaseEntity } from './base-entity';
+import { z } from 'zod';
+
+export const growthFormSchema = z
+	.object({
+		date: z.string().min(1),
+		headCircumference: z.string(),
+		height: z.string(),
+		notes: z.string(),
+		weight: z.string(),
+	})
+	.refine(
+		(values) =>
+			values.weight.length > 0 ||
+			values.height.length > 0 ||
+			values.headCircumference.length > 0,
+		{
+			message: 'Please enter at least a weight, height, or head circumference.',
+			path: ['weight'],
+		},
+	);
+
+export type GrowthFormValues = z.infer<typeof growthFormSchema>;
 
 export interface GrowthMeasurement extends BaseEntity {
 	// ISO string

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,3 +1,14 @@
+import { z } from 'zod';
+
+export const profileFormSchema = z.object({
+	color: z.string().min(1),
+	dob: z.string().min(1),
+	name: z.string().min(1),
+	sex: z.enum(['boy', 'girl']),
+});
+
+export type ProfileFormValues = z.infer<typeof profileFormSchema>;
+
 export type Sex = 'boy' | 'girl';
 
 export interface Profile {

--- a/src/types/teething.ts
+++ b/src/types/teething.ts
@@ -1,4 +1,12 @@
 import type { BaseEntity } from './base-entity';
+import { z } from 'zod';
+
+export const teethingFormSchema = z.object({
+	date: z.string().min(1),
+	notes: z.string(),
+});
+
+export type TeethingFormValues = z.infer<typeof teethingFormSchema>;
 
 export interface Tooth extends BaseEntity {
 	date?: string; // ISO date of eruption


### PR DESCRIPTION
## Summary
- migrates all user-facing forms to `react-hook-form` + `zod` for consistent create/edit handling:
  - `ProfileForm`
  - `ProductForm`
  - `DiaperForm`
  - `FeedingForm`
  - `EventForm`
  - `GrowthForm`
  - `TeethingForm`
- adds typed form schemas in `src/types/*` for each form domain
- updates `Input` and `Textarea` to `forwardRef` so RHF registration works reliably
- adds `DiaperForm` tests and stabilizes async assertions in `FeedingForm` tests

## Why not reuse #744 directly
I reviewed #744 and it is currently not safe to merge as-is:
- it is based on an old branch and has merge conflicts with `main`
- it includes many unrelated changes (hooks/sync/data page) beyond form refactoring
- it does not typecheck cleanly against current `main`

This PR keeps scope focused on form uniformity only.

## Verification
- `pnpm exec next typegen`
- `pnpm exec tsc --noEmit`
- `pnpm test src/app/feeding/components/feeding-form.test.tsx src/app/diaper/components/diaper-form.test.tsx --run`
