### PR TITLE
Optimize Migration Performance

### DIFF
--- a/src/migrations/2026-03-01-rename-diaper-abnormalities-to-notes.ts
+++ b/src/migrations/2026-03-01-rename-diaper-abnormalities-to-notes.ts
@@ -37,26 +37,24 @@ export const renameDiaperAbnormalitiesToNotesMigration: Migration = {
 		let hasChanges = false;
 
 		store.transaction(() => {
-			const diaperChanges = store.getTable(TABLE_IDS.DIAPER_CHANGES);
-
-			for (const [rowId, row] of Object.entries(diaperChanges)) {
-				const legacy = row.abnormalities as
-					| DiaperChangeBefore20260301['abnormalities']
-					| undefined;
-				const current = row.notes as
-					| DiaperChangeAfter20260301['notes']
-					| undefined;
+			store.forEachRow(TABLE_IDS.DIAPER_CHANGES, (rowId) => {
+				const legacy = store.getCell(
+					TABLE_IDS.DIAPER_CHANGES,
+					rowId,
+					'abnormalities',
+				);
+				const current = store.getCell(TABLE_IDS.DIAPER_CHANGES, rowId, 'notes');
 
 				if (typeof legacy === 'string' && typeof current !== 'string') {
 					store.setCell(TABLE_IDS.DIAPER_CHANGES, rowId, 'notes', legacy);
 					hasChanges = true;
 				}
 
-				if (row.abnormalities !== undefined) {
+				if (legacy !== undefined) {
 					store.delCell(TABLE_IDS.DIAPER_CHANGES, rowId, 'abnormalities');
 					hasChanges = true;
 				}
-			}
+			});
 		});
 
 		return hasChanges;

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -28,9 +28,14 @@ export function runMigrations(
 	let hasChanges = false;
 
 	for (const migration of migrations) {
-		let wasAlreadyApplied = false;
+		if (store.hasRow(INTERNAL_TABLE_IDS.MIGRATIONS, migration.id)) {
+			skippedMigrationIds.push(migration.id);
+			continue;
+		}
 
+		let wasAlreadyApplied = false;
 		store.transaction(() => {
+			// Double-check inside transaction in case of concurrent runs
 			if (store.hasRow(INTERNAL_TABLE_IDS.MIGRATIONS, migration.id)) {
 				wasAlreadyApplied = true;
 				return;


### PR DESCRIPTION
The migration system was adding significant delay to the initial load because it was cloning entire tables into memory using `store.getTable()`. This change refactors migrations to use `store.forEachRow()` and `store.getCell()`, which processes data efficiently without full table copies. Additionally, the migration runner was optimized to skip transaction overhead for already applied migrations. Performance was verified with a 100k record dataset on Pixel 7a emulation.

---
*PR created automatically by Jules for task [498101134914035777](https://jules.google.com/task/498101134914035777) started by @clentfort*