### PR TITLE
Sticky Navigation Header with Scroll-Linked Animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,14 +50,14 @@
 
 	--breakpoint-xs: 480px;
 
-	--header-height-expanded: 172px;
-	--header-height-sticky: 64px;
+	--header-height-expanded: 180px;
+	--header-height-sticky: 68px;
 	--logo-size-expanded: 48px;
-	--logo-size-sticky: 24px;
+	--logo-size-sticky: 28px;
 	--logo-top-expanded: 16px;
-	--logo-top-sticky: 20px;
+	--logo-top-sticky: 10px;
 	--logo-left-expanded: 16px;
-	--logo-left-sticky: 16px;
+	--logo-left-sticky: 12px;
 
 	@keyframes accordion-down {
 		from {

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -85,6 +85,13 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						</div>
 
 						<div
+							className="w-full !transition-none"
+							style={{
+								height: `calc(10px * var(--header-scroll-progress))`,
+							}}
+						/>
+
+						<div
 							className="relative flex-grow flex items-center justify-between px-4 !transition-none"
 							style={{
 								marginTop: `calc(1rem * (1 - var(--header-scroll-progress)))`,
@@ -131,7 +138,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 							className="w-full flex flex-row justify-between gap-2 px-4 !transition-none"
 							style={{
 								marginBottom: `calc(1rem * (1 - var(--header-scroll-progress)))`,
-								maxHeight: `calc(40px * (1 - var(--header-scroll-progress)))`,
+								maxHeight: `calc(60px * (1 - var(--header-scroll-progress)))`,
 								opacity: `calc(1 - var(--header-scroll-progress))`,
 								overflow: 'hidden',
 								transform: `translateY(calc(-20px * var(--header-scroll-progress)))`,

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -42,9 +42,10 @@ export default function Navigation() {
 	const pathname = usePathname();
 	return (
 		<div
-			className="mb-6 !transition-none"
+			className="!transition-none"
 			style={{
-				marginLeft: `calc(32px * var(--header-scroll-progress))`,
+				marginBottom: `calc(1.5rem * (1 - var(--header-scroll-progress)))`,
+				marginLeft: `calc(40px * var(--header-scroll-progress))`,
 			}}
 		>
 			<NavigationMenu className="w-full max-w-none">


### PR DESCRIPTION
This change introduces a "premium feel" sticky header for AdaMeter. As the user scrolls, the header smoothly condenses from a multi-row expanded view into a single-line sticky navigation bar. 

Key technical aspects:
- **Scroll Tracking**: A `window` scroll listener in `RootLayout` updates a `--header-scroll-progress` CSS variable on the main container.
- **CSS-Driven Interpolation**: All transitions (height, opacity, position, scale) are calculated in CSS using `calc()` based on the scroll progress variable.
- **Layout Stability**: Elements that disappear (title, settings, activity info) collapse their `max-height` and `margin` while using `overflow: hidden` to prevent them from pushing down the sticky content.
- **Responsive Design**: By using `absolute` positioning for the shrunken logo within the `sticky` header container, the logo remains correctly aligned even on larger screens where the content is centered.
- **Performance**: Standard CSS transitions are disabled on these specific elements via `!transition-none` to avoid visual stuttering when updating styles directly from the scroll event.

---
*PR created automatically by Jules for task [2984777823472054914](https://jules.google.com/task/2984777823472054914) started by @clentfort*