### PR TITLE
Improve test coverage for getRangeDates utility

### DIFF
--- a/src/utils/get-range-dates.test.ts
+++ b/src/utils/get-range-dates.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRangeDates } from './get-range-dates';
+
+describe('getRangeDates', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should return a range from Unix epoch to now when timeRange is "all"', () => {
+		const result = getRangeDates('all');
+		expect(result.primary.from.getTime()).toBe(0);
+		expect(result.primary.to).toEqual(new Date('2024-01-15T12:00:00Z'));
+		expect(result.secondary).toBeUndefined();
+	});
+});


### PR DESCRIPTION
This change improves the project's test coverage by adding a new unit test for the `getRangeDates` utility function. 

### Changes:
- Created `src/utils/get-range-dates.test.ts` to test `src/utils/get-range-dates.ts`.
- Implemented a test case for the `all` time range, verifying that it returns the expected `from` (Unix epoch) and `to` (current time) dates.
- Mocked system time using `vi.useFakeTimers()` for deterministic results.

### Verification:
- Ran `pnpm vitest run --coverage.enabled`.
- Confirmed that `src/utils/get-range-dates.test.ts` passes.
- Verified that coverage for `src/utils/get-range-dates.ts` increased from 0% to 33.33%.
- Ensured all existing tests continue to pass.
- Verified codebase cleanliness by removing temporary coverage logs before submission.

---
*PR created automatically by Jules for task [10423071707142592996](https://jules.google.com/task/10423071707142592996) started by @clentfort*