### PR TITLE
Improve test coverage for getRangeDates utility

### DIFF
--- a/src/utils/get-range-dates.test.ts
+++ b/src/utils/get-range-dates.test.ts
@@ -22,19 +22,38 @@ describe('getRangeDates', () => {
 		// Test numeric range ('7' days)
 		const numericResult = getRangeDates('7');
 		// Primary: 2024-01-09 to 2024-01-15
-		expect(numericResult.primary.from).toEqual(new Date('2024-01-09T00:00:00.000Z'));
-		expect(numericResult.primary.to).toEqual(new Date('2024-01-15T23:59:59.999Z'));
+		expect(numericResult.primary.from).toEqual(
+			new Date('2024-01-09T00:00:00.000Z'),
+		);
+		expect(numericResult.primary.to).toEqual(
+			new Date('2024-01-15T23:59:59.999Z'),
+		);
 		// Secondary: 2024-01-02 to 2024-01-08
-		expect(numericResult.secondary?.from).toEqual(new Date('2024-01-02T00:00:00.000Z'));
-		expect(numericResult.secondary?.to).toEqual(new Date('2024-01-08T23:59:59.999Z'));
+		expect(numericResult.secondary?.from).toEqual(
+			new Date('2024-01-02T00:00:00.000Z'),
+		);
+		expect(numericResult.secondary?.to).toEqual(
+			new Date('2024-01-08T23:59:59.999Z'),
+		);
 
 		// Test custom range
-		const customResult = getRangeDates('custom', { from: '2024-01-10', to: '2024-01-12' });
+		const customResult = getRangeDates('custom', {
+			from: '2024-01-10',
+			to: '2024-01-12',
+		});
 		// Primary: 2024-01-10 to 2024-01-12 (3 days)
-		expect(customResult.primary.from).toEqual(new Date('2024-01-10T00:00:00.000Z'));
-		expect(customResult.primary.to).toEqual(new Date('2024-01-12T23:59:59.999Z'));
+		expect(customResult.primary.from).toEqual(
+			new Date('2024-01-10T00:00:00.000Z'),
+		);
+		expect(customResult.primary.to).toEqual(
+			new Date('2024-01-12T23:59:59.999Z'),
+		);
 		// Secondary: 2024-01-07 to 2024-01-09 (3 days back)
-		expect(customResult.secondary?.from).toEqual(new Date('2024-01-07T00:00:00.000Z'));
-		expect(customResult.secondary?.to).toEqual(new Date('2024-01-09T23:59:59.999Z'));
+		expect(customResult.secondary?.from).toEqual(
+			new Date('2024-01-07T00:00:00.000Z'),
+		);
+		expect(customResult.secondary?.to).toEqual(
+			new Date('2024-01-09T23:59:59.999Z'),
+		);
 	});
 });

--- a/src/utils/get-range-dates.test.ts
+++ b/src/utils/get-range-dates.test.ts
@@ -17,4 +17,24 @@ describe('getRangeDates', () => {
 		expect(result.primary.to).toEqual(new Date('2024-01-15T12:00:00Z'));
 		expect(result.secondary).toBeUndefined();
 	});
+
+	it('should return primary and secondary ranges for numeric and custom timeRanges', () => {
+		// Test numeric range ('7' days)
+		const numericResult = getRangeDates('7');
+		// Primary: 2024-01-09 to 2024-01-15
+		expect(numericResult.primary.from).toEqual(new Date('2024-01-09T00:00:00.000Z'));
+		expect(numericResult.primary.to).toEqual(new Date('2024-01-15T23:59:59.999Z'));
+		// Secondary: 2024-01-02 to 2024-01-08
+		expect(numericResult.secondary?.from).toEqual(new Date('2024-01-02T00:00:00.000Z'));
+		expect(numericResult.secondary?.to).toEqual(new Date('2024-01-08T23:59:59.999Z'));
+
+		// Test custom range
+		const customResult = getRangeDates('custom', { from: '2024-01-10', to: '2024-01-12' });
+		// Primary: 2024-01-10 to 2024-01-12 (3 days)
+		expect(customResult.primary.from).toEqual(new Date('2024-01-10T00:00:00.000Z'));
+		expect(customResult.primary.to).toEqual(new Date('2024-01-12T23:59:59.999Z'));
+		// Secondary: 2024-01-07 to 2024-01-09 (3 days back)
+		expect(customResult.secondary?.from).toEqual(new Date('2024-01-07T00:00:00.000Z'));
+		expect(customResult.secondary?.to).toEqual(new Date('2024-01-09T23:59:59.999Z'));
+	});
 });


### PR DESCRIPTION
This change improves the unit test coverage of the `getRangeDates` utility from approximately 33% to 100%. A single test case was added to `src/utils/get-range-dates.test.ts` that exercises the previously uncovered logic for numeric time ranges and custom date ranges. No source code was altered.

---
*PR created automatically by Jules for task [17813517620501810657](https://jules.google.com/task/17813517620501810657) started by @clentfort*