### PR TITLE
Hide Feeding Section and Add Daily Diaper Stats

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,8 +50,9 @@
 
 	--breakpoint-xs: 480px;
 
-	--header-height-expanded: 176px;
-	--header-height-sticky: 68px;
+	--header-height-expanded: 152px;
+	--header-height-sticky: 50px;
+	--header-content-gap: 10px;
 	--logo-size-expanded: 48px;
 	--logo-size-sticky: 28px;
 	--logo-top-expanded: 16px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,7 +50,7 @@
 
 	--breakpoint-xs: 480px;
 
-	--header-height-expanded: 192px;
+	--header-height-expanded: 176px;
 	--header-height-sticky: 68px;
 	--logo-size-expanded: 48px;
 	--logo-size-sticky: 28px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,7 +56,7 @@
 	--logo-size-sticky: 28px;
 	--logo-top-expanded: 16px;
 	--logo-top-sticky: 10px;
-	--logo-left-expanded: 16px;
+	--logo-left-expanded: 12px;
 	--logo-left-sticky: 12px;
 
 	@keyframes accordion-down {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,13 +50,13 @@
 
 	--breakpoint-xs: 480px;
 
-	--header-height-expanded: 180px;
+	--header-height-expanded: 192px;
 	--header-height-sticky: 68px;
 	--logo-size-expanded: 48px;
 	--logo-size-sticky: 28px;
 	--logo-top-expanded: 16px;
 	--logo-top-sticky: 10px;
-	--logo-left-expanded: 12px;
+	--logo-left-expanded: 16px;
 	--logo-left-sticky: 12px;
 
 	@keyframes accordion-down {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,18 @@
 import { redirect } from 'next/navigation';
 import { useEffect } from 'react';
 import { SplashScreen } from '@/components/splash-screen';
+import { useShowFeeding } from '@/hooks/use-show-feeding';
 
 export default function HomePage() {
+	const [showFeeding] = useShowFeeding();
+
 	useEffect(() => {
-		redirect('/feeding');
-	}, []);
+		if (showFeeding) {
+			redirect('/feeding');
+		} else {
+			redirect('/diaper');
+		}
+	}, [showFeeding]);
 
 	return <SplashScreen />;
 }

--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -17,6 +17,7 @@ import { useLanguage } from '@/contexts/i18n-context';
 import { Currency, useCurrency } from '@/hooks/use-currency';
 import { useDevMode } from '@/hooks/use-dev-mode';
 import { useShowComparisonCharts } from '@/hooks/use-show-comparison-charts';
+import { useShowFeeding } from '@/hooks/use-show-feeding';
 import { Locale } from '@/i18n';
 import { SettingsHeader } from '../components/settings-header';
 
@@ -27,6 +28,7 @@ export default function AppearanceSettingsPage() {
 	const [devMode, setDevMode] = useDevMode();
 	const [showComparisonCharts, setShowComparisonCharts] =
 		useShowComparisonCharts();
+	const [showFeeding, setShowFeeding] = useShowFeeding();
 
 	const updateLocale = async (code: Locale) => {
 		await setLocale(code);
@@ -145,6 +147,26 @@ export default function AppearanceSettingsPage() {
 									checked={showComparisonCharts}
 									id="butterfly"
 									onCheckedChange={setShowComparisonCharts}
+								/>
+							</div>
+
+							<div className="flex items-center justify-between">
+								<div className="space-y-0.5">
+									<Label className="text-sm font-medium" htmlFor="show-feeding">
+										<fbt desc="Label for show feeding setting">
+											Show Feeding
+										</fbt>
+									</Label>
+									<p className="text-xs text-muted-foreground">
+										<fbt desc="Description for show feeding setting">
+											Show breastfeeding and feeding tracking features
+										</fbt>
+									</p>
+								</div>
+								<Switch
+									checked={showFeeding}
+									id="show-feeding"
+									onCheckedChange={setShowFeeding}
 								/>
 							</div>
 

--- a/src/components/root-layout/diaper-stats.test.tsx
+++ b/src/components/root-layout/diaper-stats.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TinyBaseTestWrapper } from '@/test-utils/tinybase-test-wrapper';
+import DiaperStats from './diaper-stats';
+
+// Mock the hook to provide predictable values
+vi.mock('@/hooks/use-today-diaper-stats', () => ({
+	useTodayDiaperStats: () => ({ stoolCount: 2, urineCount: 5 }),
+}));
+
+describe('DiaperStats', () => {
+	it('should render today counts', () => {
+		render(<DiaperStats />, { wrapper: TinyBaseTestWrapper });
+
+		expect(screen.getByText('5')).toBeDefined();
+		expect(screen.getByText('2')).toBeDefined();
+		expect(screen.getByText('Diapers Today')).toBeDefined();
+	});
+});

--- a/src/components/root-layout/diaper-stats.tsx
+++ b/src/components/root-layout/diaper-stats.tsx
@@ -1,0 +1,22 @@
+import { useTodayDiaperStats } from '@/hooks/use-today-diaper-stats';
+
+export default function DiaperStats() {
+	const { stoolCount, urineCount } = useTodayDiaperStats();
+
+	return (
+		<div className="text-center bg-muted/20 rounded-lg p-2 flex-1 flex flex-col justify-center">
+			<div className="flex items-center justify-center gap-1">
+				<span className="text-sm">👶</span>
+				<p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
+					<fbt desc="Label for today's diaper stats">Diapers Today</fbt>
+				</p>
+			</div>
+			<div className="flex items-baseline justify-center gap-1">
+				<span className="text-sm font-medium tabular-nums">{urineCount}</span>
+				<span className="text-xs mr-2">💧</span>
+				<span className="text-sm font-medium tabular-nums">{stoolCount}</span>
+				<span className="text-xs">💩</span>
+			</div>
+		</div>
+	);
+}

--- a/src/components/root-layout/diaper-stats.tsx
+++ b/src/components/root-layout/diaper-stats.tsx
@@ -1,22 +1,20 @@
 import { useTodayDiaperStats } from '@/hooks/use-today-diaper-stats';
+import HeaderIndicator from './header-indicator';
 
 export default function DiaperStats() {
 	const { stoolCount, urineCount } = useTodayDiaperStats();
 
 	return (
-		<div className="text-center bg-muted/20 rounded-lg p-2 flex-1 flex flex-col justify-center">
-			<div className="flex items-center justify-center gap-1">
-				<span className="text-sm">👶</span>
-				<p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-					<fbt desc="Label for today's diaper stats">Diapers Today</fbt>
-				</p>
-			</div>
+		<HeaderIndicator
+			icon="👶"
+			label={<fbt desc="Label for today's diaper stats">Diapers Today</fbt>}
+		>
 			<div className="flex items-baseline justify-center gap-1">
-				<span className="text-sm font-medium tabular-nums">{urineCount}</span>
+				<span className="tabular-nums">{urineCount}</span>
 				<span className="text-xs mr-2">💧</span>
-				<span className="text-sm font-medium tabular-nums">{stoolCount}</span>
+				<span className="tabular-nums">{stoolCount}</span>
 				<span className="text-xs">💩</span>
 			</div>
-		</div>
+		</HeaderIndicator>
 	);
 }

--- a/src/components/root-layout/header-indicator.test.tsx
+++ b/src/components/root-layout/header-indicator.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import HeaderIndicator from './header-indicator';
+
+describe('HeaderIndicator', () => {
+	it('should render label and children', () => {
+		render(
+			<HeaderIndicator icon="👶" label="Test Label">
+				<div data-testid="child">Test Content</div>
+			</HeaderIndicator>,
+		);
+
+		expect(screen.getByText('Test Label')).toBeDefined();
+		expect(screen.getByTestId('child')).toBeDefined();
+		expect(screen.getByText('👶')).toBeDefined();
+	});
+});

--- a/src/components/root-layout/header-indicator.tsx
+++ b/src/components/root-layout/header-indicator.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+interface HeaderIndicatorProps {
+	children: ReactNode;
+	icon: ReactNode;
+	label: ReactNode;
+}
+
+export default function HeaderIndicator({
+	children,
+	icon,
+	label,
+}: HeaderIndicatorProps) {
+	return (
+		<div className="text-center bg-muted/20 rounded-lg p-2 flex-1 flex flex-col justify-center">
+			<div className="flex items-center justify-center gap-1">
+				<span className="text-sm">{icon}</span>
+				<p className="text-xs text-muted-foreground font-medium">{label}</p>
+			</div>
+			<div className="text-sm font-medium">{children}</div>
+		</div>
+	);
+}

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -98,7 +98,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						<div
 							className="relative flex-grow flex items-center justify-between px-4 !transition-none"
 							style={{
-								marginTop: `calc(1.5rem * (1 - var(--header-scroll-progress)))`,
+								marginTop: `calc(0.75rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(48px * (1 - var(--header-scroll-progress)))`,
 								overflow: 'hidden',
 							}}
@@ -141,7 +141,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						<div
 							className="w-full flex flex-row justify-between gap-2 px-4 !transition-none"
 							style={{
-								marginBottom: `calc(1rem * (1 - var(--header-scroll-progress)))`,
+								marginBottom: `calc(0.5rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(60px * (1 - var(--header-scroll-progress)))`,
 								opacity: `calc(1 - var(--header-scroll-progress))`,
 								overflow: 'hidden',

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -9,6 +9,8 @@ import { usePathname } from 'next/navigation';
 import { Suspense, useEffect, useRef } from 'react';
 import { useLatestDiaperChangeRecord } from '@/hooks/use-diaper-changes';
 import { useLatestFeedingSessionRecord } from '@/hooks/use-feeding-sessions';
+import { useShowFeeding } from '@/hooks/use-show-feeding';
+import { useTodayDiaperStats } from '@/hooks/use-today-diaper-stats';
 import ConsoleDebugger from '../console-debugger';
 import ProfilePrompt from '../profile-prompt';
 import { Button } from '../ui/button';
@@ -25,6 +27,8 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
 	const latestFeedingSession = useLatestFeedingSessionRecord();
 	const latestDiaperChange = useLatestDiaperChangeRecord();
+	const [showFeeding] = useShowFeeding();
+	const { stoolCount, urineCount } = useTodayDiaperStats();
 	const pathname = usePathname();
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -145,14 +149,37 @@ export default function RootLayout({ children }: RootLayoutProps) {
 								transform: `translateY(calc(-20px * var(--header-scroll-progress)))`,
 							}}
 						>
-							<TimeSince
-								icon="🍼"
-								lastChange={latestFeedingSession?.endTime || null}
-							>
-								<fbt desc="Short label indicating when a feeding was last recorded">
-									Last Feeding
-								</fbt>
-							</TimeSince>
+							{showFeeding ? (
+								<TimeSince
+									icon="🍼"
+									lastChange={latestFeedingSession?.endTime || null}
+								>
+									<fbt desc="Short label indicating when a feeding was last recorded">
+										Last Feeding
+									</fbt>
+								</TimeSince>
+							) : (
+								<div className="flex flex-col flex-1 bg-muted/20 rounded-lg p-2 justify-center">
+									<div className="flex items-center justify-center gap-1.5 mb-0.5">
+										<span className="text-sm">👶</span>
+										<span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+											<fbt desc="Label for today's diaper stats">
+												Diapers Today
+											</fbt>
+										</span>
+									</div>
+									<div className="flex items-baseline justify-center gap-1">
+										<span className="text-sm font-medium tabular-nums">
+											{urineCount}
+										</span>
+										<span className="text-xs mr-2">💧</span>
+										<span className="text-sm font-medium tabular-nums">
+											{stoolCount}
+										</span>
+										<span className="text-xs">💩</span>
+									</div>
+								</div>
+							)}
 
 							<TimeSince
 								icon="👶"

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -98,7 +98,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						<div
 							className="relative flex-grow flex items-center justify-between px-4 !transition-none"
 							style={{
-								marginTop: `calc(1rem * (1 - var(--header-scroll-progress)))`,
+								marginTop: `calc(1.5rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(48px * (1 - var(--header-scroll-progress)))`,
 								overflow: 'hidden',
 							}}
@@ -139,7 +139,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						</div>
 
 						<div
-							className="w-full flex flex-row justify-between gap-2 px-4 pl-14 !transition-none sm:pl-4"
+							className="w-full flex flex-row justify-between gap-2 px-4 !transition-none"
 							style={{
 								marginBottom: `calc(1rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(60px * (1 - var(--header-scroll-progress)))`,

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -10,11 +10,11 @@ import { Suspense, useEffect, useRef } from 'react';
 import { useLatestDiaperChangeRecord } from '@/hooks/use-diaper-changes';
 import { useLatestFeedingSessionRecord } from '@/hooks/use-feeding-sessions';
 import { useShowFeeding } from '@/hooks/use-show-feeding';
-import { useTodayDiaperStats } from '@/hooks/use-today-diaper-stats';
 import ConsoleDebugger from '../console-debugger';
 import ProfilePrompt from '../profile-prompt';
 import { Button } from '../ui/button';
 import { Toaster } from '../ui/toaster';
+import DiaperStats from './diaper-stats';
 import { Footer } from './footer';
 import Navigation from './navigation';
 import { RoomInviteHandler } from './room-invite-handler';
@@ -28,7 +28,6 @@ export default function RootLayout({ children }: RootLayoutProps) {
 	const latestFeedingSession = useLatestFeedingSessionRecord();
 	const latestDiaperChange = useLatestDiaperChangeRecord();
 	const [showFeeding] = useShowFeeding();
-	const { stoolCount, urineCount } = useTodayDiaperStats();
 	const pathname = usePathname();
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -169,28 +168,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 								</fbt>
 							</TimeSince>
 
-							{!showFeeding && (
-								<div className="flex flex-col flex-1 bg-muted/20 rounded-lg p-2 justify-center">
-									<div className="flex items-center justify-center gap-1.5 mb-0.5">
-										<span className="text-sm">👶</span>
-										<span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-											<fbt desc="Label for today's diaper stats">
-												Diapers Today
-											</fbt>
-										</span>
-									</div>
-									<div className="flex items-baseline justify-center gap-1">
-										<span className="text-sm font-medium tabular-nums">
-											{urineCount}
-										</span>
-										<span className="text-xs mr-2">💧</span>
-										<span className="text-sm font-medium tabular-nums">
-											{stoolCount}
-										</span>
-										<span className="text-xs">💩</span>
-									</div>
-								</div>
-							)}
+							{!showFeeding && <DiaperStats />}
 						</div>
 						<div className="px-4">
 							<Navigation />

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -98,7 +98,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						<div
 							className="relative flex-grow flex items-center justify-between px-4 !transition-none"
 							style={{
-								marginTop: `calc(0.75rem * (1 - var(--header-scroll-progress)))`,
+								marginTop: `calc(1rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(48px * (1 - var(--header-scroll-progress)))`,
 								overflow: 'hidden',
 							}}
@@ -141,8 +141,8 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						<div
 							className="w-full flex flex-row justify-between gap-2 px-4 !transition-none"
 							style={{
-								marginBottom: `calc(0.5rem * (1 - var(--header-scroll-progress)))`,
-								maxHeight: `calc(60px * (1 - var(--header-scroll-progress)))`,
+								marginBottom: `calc(0.25rem * (1 - var(--header-scroll-progress)))`,
+								maxHeight: `calc(56px * (1 - var(--header-scroll-progress)))`,
 								opacity: `calc(1 - var(--header-scroll-progress))`,
 								overflow: 'hidden',
 								transform: `translateY(calc(-20px * var(--header-scroll-progress)))`,
@@ -175,7 +175,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						</div>
 					</div>
 				)}
-				<div className="p-4 w-full">
+				<div
+					className="px-4 pb-4 w-full"
+					style={{ paddingTop: 'var(--header-content-gap)' }}
+				>
 					<Suspense fallback={null}>
 						<RoomInviteHandler />
 					</Suspense>

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -149,7 +149,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 								transform: `translateY(calc(-20px * var(--header-scroll-progress)))`,
 							}}
 						>
-							{showFeeding ? (
+							{showFeeding && (
 								<TimeSince
 									icon="🍼"
 									lastChange={latestFeedingSession?.endTime || null}
@@ -158,7 +158,18 @@ export default function RootLayout({ children }: RootLayoutProps) {
 										Last Feeding
 									</fbt>
 								</TimeSince>
-							) : (
+							)}
+
+							<TimeSince
+								icon="👶"
+								lastChange={latestDiaperChange?.timestamp || null}
+							>
+								<fbt desc="A short label indicating when a diaper was last changed">
+									Last Diaper Change
+								</fbt>
+							</TimeSince>
+
+							{!showFeeding && (
 								<div className="flex flex-col flex-1 bg-muted/20 rounded-lg p-2 justify-center">
 									<div className="flex items-center justify-center gap-1.5 mb-0.5">
 										<span className="text-sm">👶</span>
@@ -180,15 +191,6 @@ export default function RootLayout({ children }: RootLayoutProps) {
 									</div>
 								</div>
 							)}
-
-							<TimeSince
-								icon="👶"
-								lastChange={latestDiaperChange?.timestamp || null}
-							>
-								<fbt desc="A short label indicating when a diaper was last changed">
-									Last Diaper Change
-								</fbt>
-							</TimeSince>
 						</div>
 						<div className="px-4">
 							<Navigation />

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -139,7 +139,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 						</div>
 
 						<div
-							className="w-full flex flex-row justify-between gap-2 px-4 !transition-none"
+							className="w-full flex flex-row justify-between gap-2 px-4 pl-14 !transition-none sm:pl-4"
 							style={{
 								marginBottom: `calc(1rem * (1 - var(--header-scroll-progress)))`,
 								maxHeight: `calc(60px * (1 - var(--header-scroll-progress)))`,

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -55,7 +55,7 @@ export default function Navigation() {
 			className="!transition-none"
 			style={{
 				marginBottom: `calc(1.5rem * (1 - var(--header-scroll-progress)))`,
-				marginLeft: `calc(40px * var(--header-scroll-progress))`,
+				marginLeft: `calc(48px * var(--header-scroll-progress))`,
 			}}
 		>
 			<NavigationMenu className="w-full max-w-none">

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -54,7 +54,6 @@ export default function Navigation() {
 		<div
 			className="!transition-none"
 			style={{
-				marginBottom: `calc(1.5rem * (1 - var(--header-scroll-progress)))`,
 				marginLeft: `calc(48px * var(--header-scroll-progress))`,
 			}}
 		>

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -59,9 +59,7 @@ export default function Navigation() {
 			}}
 		>
 			<NavigationMenu className="w-full max-w-none">
-				<NavigationMenuList
-					className={`w-full grid ${visiblePages.length === 4 ? 'grid-cols-4' : 'grid-cols-5'}`}
-				>
+				<NavigationMenuList className="w-full grid grid-flow-col auto-cols-fr">
 					{visiblePages.map((page) => {
 						const isActive = pathname === page.path;
 						return (

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -8,6 +8,7 @@ import {
 	NavigationMenuList,
 	navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu';
+import { useShowFeeding } from '@/hooks/use-show-feeding';
 import '@/i18n';
 
 const pages = [
@@ -40,6 +41,15 @@ const pages = [
 
 export default function Navigation() {
 	const pathname = usePathname();
+	const [showFeeding] = useShowFeeding();
+
+	const visiblePages = pages.filter((page) => {
+		if (page.path === '/feeding' && !showFeeding) {
+			return false;
+		}
+		return true;
+	});
+
 	return (
 		<div
 			className="!transition-none"
@@ -49,8 +59,10 @@ export default function Navigation() {
 			}}
 		>
 			<NavigationMenu className="w-full max-w-none">
-				<NavigationMenuList className="w-full grid grid-cols-5">
-					{pages.map((page) => {
+				<NavigationMenuList
+					className={`w-full grid ${visiblePages.length === 4 ? 'grid-cols-4' : 'grid-cols-5'}`}
+				>
+					{visiblePages.map((page) => {
 						const isActive = pathname === page.path;
 						return (
 							<NavigationMenuItem key={page.path}>

--- a/src/components/root-layout/time-since.tsx
+++ b/src/components/root-layout/time-since.tsx
@@ -2,6 +2,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { fbt } from 'fbtee';
 import { ReactNode, useContext, useEffect, useState } from 'react';
 import { I18nContext } from '@/contexts/i18n-context';
+import HeaderIndicator from './header-indicator';
 
 interface TimeSinceLastDiaperProps {
 	children: ReactNode;
@@ -42,17 +43,13 @@ export default function TimeSince({
 	}, [lastChange, locale]);
 
 	return (
-		<div className="text-center bg-muted/20 rounded-lg p-2 flex-1">
-			<div className="flex items-center justify-center gap-1">
-				<span className="text-sm">{icon}</span>
-				<p className="text-xs text-muted-foreground">{children}</p>
-			</div>
-			<p className="text-sm font-medium">
+		<HeaderIndicator icon={icon} label={children}>
+			<p>
 				<fbt desc="Time since an event happened">
 					<fbt:param name="timeSince">{timeSince}</fbt:param>
 					ago
 				</fbt>
 			</p>
-		</div>
+		</HeaderIndicator>
 	);
 }

--- a/src/hooks/use-show-feeding.test.tsx
+++ b/src/hooks/use-show-feeding.test.tsx
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { STORE_VALUE_SHOW_FEEDING } from '@/lib/tinybase-sync/constants';
+import {
+	createTestStore,
+	TinyBaseTestWrapper,
+} from '@/test-utils/tinybase-test-wrapper';
+import { useShowFeeding } from './use-show-feeding';
+
+describe('useShowFeeding', () => {
+	it('should default to true', () => {
+		const { result } = renderHook(() => useShowFeeding(), {
+			wrapper: TinyBaseTestWrapper,
+		});
+		expect(result.current[0]).toBe(true);
+	});
+
+	it('should return value from store', () => {
+		const store = createTestStore();
+		store.setValue(STORE_VALUE_SHOW_FEEDING, false);
+
+		const { result } = renderHook(() => useShowFeeding(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		expect(result.current[0]).toBe(false);
+	});
+
+	it('should update store when setter is called', () => {
+		const store = createTestStore();
+		const { result } = renderHook(() => useShowFeeding(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		act(() => {
+			result.current[1](false);
+		});
+
+		expect(store.getValue(STORE_VALUE_SHOW_FEEDING)).toBe(false);
+		expect(result.current[0]).toBe(false);
+	});
+});

--- a/src/hooks/use-show-feeding.ts
+++ b/src/hooks/use-show-feeding.ts
@@ -1,0 +1,14 @@
+import { useSetValueCallback, useValue } from 'tinybase/ui-react';
+import { STORE_VALUE_SHOW_FEEDING } from '@/lib/tinybase-sync/constants';
+
+export const useShowFeeding = () => {
+	const showFeeding = useValue(STORE_VALUE_SHOW_FEEDING) as boolean | undefined;
+
+	const setShowFeeding = useSetValueCallback(
+		STORE_VALUE_SHOW_FEEDING,
+		(newValue: boolean) => newValue,
+		[],
+	);
+
+	return [showFeeding ?? true, setShowFeeding] as const;
+};

--- a/src/hooks/use-today-diaper-stats.test.tsx
+++ b/src/hooks/use-today-diaper-stats.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TABLE_IDS } from '@/lib/tinybase-sync/constants';
+import {
+	createTestStore,
+	TinyBaseTestWrapper,
+} from '@/test-utils/tinybase-test-wrapper';
+import { useTodayDiaperStats } from './use-today-diaper-stats';
+
+describe('useTodayDiaperStats', () => {
+	it('should return zeros when no changes today', () => {
+		const store = createTestStore();
+		// Yesterday's change
+		const yesterday = new Date();
+		yesterday.setDate(yesterday.getDate() - 1);
+
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd1', {
+			containsUrine: true,
+			timestamp: yesterday.toISOString(),
+		});
+
+		const { result } = renderHook(() => useTodayDiaperStats(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		expect(result.current).toEqual({ stoolCount: 0, urineCount: 0 });
+	});
+
+	it('should count urine and stool instances for today', () => {
+		const store = createTestStore();
+		const now = new Date();
+
+		// Record 1: Urine in diaper
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd1', {
+			containsUrine: true,
+			timestamp: now.toISOString(),
+		});
+
+		// Record 2: Stool in potty
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd2', {
+			pottyStool: true,
+			timestamp: now.toISOString(),
+		});
+
+		// Record 3: Urine + Stool (merged types)
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd3', {
+			containsStool: true,
+			containsUrine: true,
+			pottyStool: true,
+			timestamp: now.toISOString(),
+		});
+
+		const { result } = renderHook(() => useTodayDiaperStats(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		// d1: +1 urine
+		// d2: +1 stool
+		// d3: +1 urine, +1 stool
+		// Total: 2 urine, 2 stool
+		expect(result.current).toEqual({ stoolCount: 2, urineCount: 2 });
+	});
+
+	it('should handle missing timestamp gracefully', () => {
+		const store = createTestStore();
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd1', {
+			containsUrine: true,
+		});
+
+		const { result } = renderHook(() => useTodayDiaperStats(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		expect(result.current).toEqual({ stoolCount: 0, urineCount: 0 });
+	});
+});

--- a/src/hooks/use-today-diaper-stats.ts
+++ b/src/hooks/use-today-diaper-stats.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useTable } from 'tinybase/ui-react';
+import { TABLE_IDS } from '@/lib/tinybase-sync/constants';
+
+export const useTodayDiaperStats = () => {
+	const table = useTable(TABLE_IDS.DIAPER_CHANGES);
+
+	return useMemo(() => {
+		let urineCount = 0;
+		let stoolCount = 0;
+
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+
+		for (const row of Object.values(table)) {
+			const timestamp = new Date(row.timestamp as string);
+			if (timestamp >= today) {
+				const hasUrine = row.containsUrine || row.pottyUrine;
+				const hasStool = row.containsStool || row.pottyStool;
+
+				if (hasUrine) {
+					urineCount++;
+				}
+				if (hasStool) {
+					stoolCount++;
+				}
+			}
+		}
+
+		return { stoolCount, urineCount };
+	}, [table]);
+};

--- a/src/lib/tinybase-sync/constants.ts
+++ b/src/lib/tinybase-sync/constants.ts
@@ -6,6 +6,7 @@ export const STORE_VALUE_CURRENCY = 'currency';
 export const STORE_VALUE_DEV_MODE = 'devMode';
 export const STORE_VALUE_FEEDING_IN_PROGRESS = 'feedingInProgress';
 export const STORE_VALUE_PROFILE = 'profile';
+export const STORE_VALUE_SHOW_FEEDING = 'showFeeding';
 
 export const TABLE_IDS = {
 	DIAPER_CHANGES: 'diaperChanges',


### PR DESCRIPTION
This PR implements the requested feature to hide the breastfeeding/feeding section and repurpose the reclaimed header space for daily diaper statistics.

Key changes:
1. **Shared Setting**: Introduced `showFeeding` in the TinyBase store so the preference syncs across all devices.
2. **Settings UI**: Added a toggle in 'Settings > Appearance' to enable/disable the feeding section.
3. **Navigation Updates**: 
   - The Feeding tab is hidden from the main menu when disabled.
   - The navigation grid automatically switches from 5 to 4 columns for balanced spacing.
   - The root URL (`/`) now redirects to `/diaper` instead of `/feeding` if the section is hidden.
4. **Header Stats**: When feeding is hidden, the "Last Feeding" indicator in the header is replaced by "Diapers Today" stats showing cumulative urine (💧) and stool (💩) instances for the current day.
5. **Stats Logic**: Implemented counting logic that treats urine/stool in a single diaper change record as one instance each, including potty uses.

Verified via manual code audit and automated translation collection.

---
*PR created automatically by Jules for task [12583162045730174745](https://jules.google.com/task/12583162045730174745) started by @clentfort*