### PR TITLE
Improve coverage for useShowComparisonCharts hook

### DIFF
--- a/src/hooks/use-show-comparison-charts.test.ts
+++ b/src/hooks/use-show-comparison-charts.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as storage from '@/lib/storage';
+import { useShowComparisonCharts } from './use-show-comparison-charts';
+
+vi.mock('@/lib/storage', async (importOriginal) => {
+	const original = (await importOriginal()) as typeof storage;
+	return {
+		...original,
+		getItem: vi.fn(),
+		setItem: vi.fn(),
+	};
+});
+
+describe('useShowComparisonCharts', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should maintain state and update storage correctly', () => {
+		// 1. Test default value and initial load
+		vi.mocked(storage.getItem).mockReturnValue(null);
+		const { result, rerender } = renderHook(() => useShowComparisonCharts());
+
+		expect(result.current[0]).toBe(true);
+		expect(storage.getItem).toHaveBeenCalledWith(
+			storage.STORAGE_KEYS.SHOW_COMPARISON_CHARTS,
+		);
+
+		// 2. Test updating state and storage
+		act(() => {
+			result.current[1](false);
+		});
+
+		expect(result.current[0]).toBe(false);
+		expect(storage.setItem).toHaveBeenCalledWith(
+			storage.STORAGE_KEYS.SHOW_COMPARISON_CHARTS,
+			'false',
+		);
+
+		// 3. Test loading existing value from storage
+		vi.mocked(storage.getItem).mockReturnValue('false');
+		rerender();
+		// Note: The hook only reads from storage on mount (useEffect with []),
+		// so we need a fresh mount to test initial load of 'false'.
+		const { result: result2 } = renderHook(() => useShowComparisonCharts());
+		expect(result2.current[0]).toBe(false);
+	});
+});

--- a/src/hooks/use-show-comparison-charts.test.ts
+++ b/src/hooks/use-show-comparison-charts.test.ts
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as storage from '@/lib/storage';
+import { getItem, setItem, STORAGE_KEYS } from '@/lib/storage';
 import { useShowComparisonCharts } from './use-show-comparison-charts';
 
 vi.mock('@/lib/storage', async (importOriginal) => {
-	const original = (await importOriginal()) as typeof storage;
+	const original = (await importOriginal()) as typeof import('@/lib/storage');
 	return {
 		...original,
 		getItem: vi.fn(),
@@ -19,13 +19,11 @@ describe('useShowComparisonCharts', () => {
 
 	it('should maintain state and update storage correctly', () => {
 		// 1. Test default value and initial load
-		vi.mocked(storage.getItem).mockReturnValue(null);
-		const { result, rerender } = renderHook(() => useShowComparisonCharts());
+		vi.mocked(getItem).mockReturnValue(null);
+		const { rerender, result } = renderHook(() => useShowComparisonCharts());
 
 		expect(result.current[0]).toBe(true);
-		expect(storage.getItem).toHaveBeenCalledWith(
-			storage.STORAGE_KEYS.SHOW_COMPARISON_CHARTS,
-		);
+		expect(getItem).toHaveBeenCalledWith(STORAGE_KEYS.SHOW_COMPARISON_CHARTS);
 
 		// 2. Test updating state and storage
 		act(() => {
@@ -33,13 +31,13 @@ describe('useShowComparisonCharts', () => {
 		});
 
 		expect(result.current[0]).toBe(false);
-		expect(storage.setItem).toHaveBeenCalledWith(
-			storage.STORAGE_KEYS.SHOW_COMPARISON_CHARTS,
+		expect(setItem).toHaveBeenCalledWith(
+			STORAGE_KEYS.SHOW_COMPARISON_CHARTS,
 			'false',
 		);
 
 		// 3. Test loading existing value from storage
-		vi.mocked(storage.getItem).mockReturnValue('false');
+		vi.mocked(getItem).mockReturnValue('false');
 		rerender();
 		// Note: The hook only reads from storage on mount (useEffect with []),
 		// so we need a fresh mount to test initial load of 'false'.


### PR DESCRIPTION
Improved test coverage by adding a unit test for the `useShowComparisonCharts` hook, which previously had 0% coverage. The new test verifies the hook's default state, its ability to load initial values from local storage, and its behavior when updating values (including synchronizing with local storage). Verified that coverage for the targeted file is now 100% and that all existing tests pass.

---
*PR created automatically by Jules for task [4273333459272436830](https://jules.google.com/task/4273333459272436830) started by @clentfort*