### PR TITLE
Fix PWA redirect on cold start when feedings are disabled

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "AdaMeter",
 	"short_name": "AdaMeter",
-	"start_url": "/feeding",
+	"start_url": "/",
 	"display": "standalone",
 	"background_color": "#faf7ee",
 	"theme_color": "#000",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,25 @@
 'use client';
 
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { SplashScreen } from '@/components/splash-screen';
 import { useShowFeeding } from '@/hooks/use-show-feeding';
 
 export default function HomePage() {
 	const [showFeeding] = useShowFeeding();
+	const router = useRouter();
 
 	useEffect(() => {
-		if (showFeeding) {
-			redirect('/feeding');
-		} else {
-			redirect('/diaper');
+		if (showFeeding === undefined) {
+			return;
 		}
-	}, [showFeeding]);
+
+		if (showFeeding) {
+			router.replace('/feeding');
+		} else {
+			router.replace('/diaper');
+		}
+	}, [showFeeding, router]);
 
 	return <SplashScreen />;
 }

--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -164,7 +164,7 @@ export default function AppearanceSettingsPage() {
 									</p>
 								</div>
 								<Switch
-									checked={showFeeding}
+									checked={showFeeding ?? true}
 									id="show-feeding"
 									onCheckedChange={setShowFeeding}
 								/>

--- a/src/components/root-layout/index.tsx
+++ b/src/components/root-layout/index.tsx
@@ -148,7 +148,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 								transform: `translateY(calc(-20px * var(--header-scroll-progress)))`,
 							}}
 						>
-							{showFeeding && (
+							{showFeeding !== false && (
 								<TimeSince
 									icon="🍼"
 									lastChange={latestFeedingSession?.endTime || null}
@@ -168,7 +168,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 								</fbt>
 							</TimeSince>
 
-							{!showFeeding && <DiaperStats />}
+							{showFeeding === false && <DiaperStats />}
 						</div>
 						<div className="px-4">
 							<Navigation />

--- a/src/components/root-layout/navigation.tsx
+++ b/src/components/root-layout/navigation.tsx
@@ -44,7 +44,7 @@ export default function Navigation() {
 	const [showFeeding] = useShowFeeding();
 
 	const visiblePages = pages.filter((page) => {
-		if (page.path === '/feeding' && !showFeeding) {
+		if (page.path === '/feeding' && showFeeding === false) {
 			return false;
 		}
 		return true;

--- a/src/hooks/use-show-feeding.test.tsx
+++ b/src/hooks/use-show-feeding.test.tsx
@@ -8,11 +8,11 @@ import {
 import { useShowFeeding } from './use-show-feeding';
 
 describe('useShowFeeding', () => {
-	it('should default to true', () => {
+	it('should default to undefined', () => {
 		const { result } = renderHook(() => useShowFeeding(), {
 			wrapper: TinyBaseTestWrapper,
 		});
-		expect(result.current[0]).toBe(true);
+		expect(result.current[0]).toBe(undefined);
 	});
 
 	it('should return value from store', () => {

--- a/src/hooks/use-show-feeding.ts
+++ b/src/hooks/use-show-feeding.ts
@@ -10,5 +10,5 @@ export const useShowFeeding = () => {
 		[],
 	);
 
-	return [showFeeding ?? true, setShowFeeding] as const;
+	return [showFeeding, setShowFeeding] as const;
 };

--- a/src/migrations/2026-04-16-set-default-show-feeding.ts
+++ b/src/migrations/2026-04-16-set-default-show-feeding.ts
@@ -1,0 +1,14 @@
+import type { Migration } from './types';
+import { STORE_VALUE_SHOW_FEEDING } from '@/lib/tinybase-sync/constants';
+
+export const setDefaultShowFeedingMigration: Migration = {
+	description: 'Set default value for showFeeding to true if not present.',
+	id: '2026-04-16-set-default-show-feeding',
+	migrate(store) {
+		if (store.getValue(STORE_VALUE_SHOW_FEEDING) === undefined) {
+			store.setValue(STORE_VALUE_SHOW_FEEDING, true);
+			return true;
+		}
+		return false;
+	},
+};

--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -20,6 +20,8 @@ const RENAME_EVENT_MIGRATION_ID =
 	'2026-03-24-rename-event-description-to-notes';
 const ASSIGN_COLORS_MIGRATION_ID =
 	'2026-03-25-assign-colors-to-diaper-products';
+const SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID =
+	'2026-04-16-set-default-show-feeding';
 
 describe('runMigrations', () => {
 	it('keeps manifest ids in sync with registered migrations', () => {
@@ -45,6 +47,7 @@ describe('runMigrations', () => {
 			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
 			CLEANUP_JUNK_DATA_MIGRATION_ID,
 			ASSIGN_COLORS_MIGRATION_ID,
+			SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
 		]);
 		expect(result.hasChanges).toBe(true);
 		expect(result.skippedMigrationIds).toEqual([]);
@@ -93,6 +96,7 @@ describe('runMigrations', () => {
 			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
 			CLEANUP_JUNK_DATA_MIGRATION_ID,
 			ASSIGN_COLORS_MIGRATION_ID,
+			SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
 		]);
 		expect(store.getCell(TABLE_IDS.DIAPER_CHANGES, 'd1', 'notes')).toBe(
 			'Legacy notes',

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -15,6 +15,7 @@ import { removeLegacyJsonCellsMigration } from './2026-03-07-remove-legacy-json-
 import { cleanupJunkDataMigration } from './2026-03-15-cleanup-junk-data';
 import { renameEventDescriptionToNotesMigration } from './2026-03-24-rename-event-description-to-notes';
 import { assignColorsToDiaperProductsMigration } from './2026-03-25-assign-colors-to-diaper-products';
+import { setDefaultShowFeedingMigration } from './2026-04-16-set-default-show-feeding';
 
 /**
  * Ordered migration list (oldest -> newest).
@@ -29,6 +30,7 @@ export const migrations: readonly Migration[] = [
 	normalizeEntityStoreRowsMigration,
 	cleanupJunkDataMigration,
 	assignColorsToDiaperProductsMigration,
+	setDefaultShowFeedingMigration,
 ];
 
 export function runMigrations(

--- a/src/migrations/manifest.ts
+++ b/src/migrations/manifest.ts
@@ -13,4 +13,5 @@ export const MIGRATION_IDS = [
 	'2026-03-07-normalize-entity-store-rows',
 	'2026-03-15-cleanup-junk-data',
 	'2026-03-25-assign-colors-to-diaper-products',
+	'2026-04-16-set-default-show-feeding',
 ] as const;

--- a/src/migrations/run-if-needed.test.ts
+++ b/src/migrations/run-if-needed.test.ts
@@ -15,6 +15,8 @@ const RENAME_EVENT_MIGRATION_ID =
 	'2026-03-24-rename-event-description-to-notes';
 const ASSIGN_COLORS_MIGRATION_ID =
 	'2026-03-25-assign-colors-to-diaper-products';
+const SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID =
+	'2026-04-16-set-default-show-feeding';
 
 describe('runMigrationsIfNeeded', () => {
 	it('detects pending migrations from migration metadata', () => {
@@ -29,6 +31,7 @@ describe('runMigrationsIfNeeded', () => {
 			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
 			CLEANUP_JUNK_DATA_MIGRATION_ID,
 			ASSIGN_COLORS_MIGRATION_ID,
+			SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
 		]) {
 			store.setRow(INTERNAL_TABLE_IDS.MIGRATIONS, id, {
 				appliedAt: Date.now(),
@@ -48,6 +51,7 @@ describe('runMigrationsIfNeeded', () => {
 			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
 			CLEANUP_JUNK_DATA_MIGRATION_ID,
 			ASSIGN_COLORS_MIGRATION_ID,
+			SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
 		]) {
 			store.setRow(INTERNAL_TABLE_IDS.MIGRATIONS, id, {
 				appliedAt: Date.now(),
@@ -87,6 +91,7 @@ describe('runMigrationsIfNeeded', () => {
 			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
 			CLEANUP_JUNK_DATA_MIGRATION_ID,
 			ASSIGN_COLORS_MIGRATION_ID,
+			SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
 		]);
 		expect(store.getCell(TABLE_IDS.DIAPER_CHANGES, 'd1', 'notes')).toBe(
 			'Legacy note',
@@ -120,6 +125,12 @@ describe('runMigrationsIfNeeded', () => {
 		).toBe(true);
 		expect(
 			store.hasRow(INTERNAL_TABLE_IDS.MIGRATIONS, ASSIGN_COLORS_MIGRATION_ID),
+		).toBe(true);
+		expect(
+			store.hasRow(
+				INTERNAL_TABLE_IDS.MIGRATIONS,
+				SET_DEFAULT_SHOW_FEEDING_MIGRATION_ID,
+			),
 		).toBe(true);
 	});
 


### PR DESCRIPTION
This change fixes an issue where the PWA would always start on the `/feeding` page regardless of whether the feeding feature was enabled. 

By changing the `start_url` to `/`, the application now boots through the `HomePage` which correctly evaluates the `showFeeding` setting from the TinyBase store before redirecting to either `/feeding` or `/diaper`. 

To support this, the `useShowFeeding` hook now returns `undefined` while the store is hydrating, allowing the `HomePage` to remain on the splash screen until a decision can be made. A new migration ensures existing users have the setting initialized to `true` (maintaining the previous default behavior once loaded). 

Additionally, redirection in `HomePage` was changed from the `redirect` function to `router.replace` to follow Next.js best practices for Client Components.

---
*PR created automatically by Jules for task [3796192209037059918](https://jules.google.com/task/3796192209037059918) started by @clentfort*