### PR TITLE
Improve test coverage for DiaperForm

### DIFF
--- a/src/app/diaper/components/diaper-form.test.tsx
+++ b/src/app/diaper/components/diaper-form.test.tsx
@@ -5,6 +5,7 @@ import {
 	render,
 	screen,
 	waitFor,
+	within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nContext } from '@/contexts/i18n-context';
@@ -141,5 +142,23 @@ describe('DiaperForm', () => {
 		expect(savedChange.pottyStool).toBe(true);
 		expect(savedChange.leakage).toBe(true);
 		expect(savedChange.temperature).toBe(38.5);
+	});
+
+	it('opens and closes the add product dialog', async () => {
+		render(<DiaperForm {...baseProps} />);
+
+		const plusButton = document.querySelector('.lucide-plus')?.closest('button');
+		expect(plusButton).toBeTruthy();
+		fireEvent.click(plusButton!);
+
+		const dialog = await screen.findByRole('dialog', { name: /add product/i });
+		expect(dialog).toBeInTheDocument();
+
+		const cancelButton = within(dialog).getByRole('button', { name: /cancel/i });
+		fireEvent.click(cancelButton);
+
+		await waitFor(() => {
+			expect(screen.queryByText(/add product/i)).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/diaper/components/diaper-form.test.tsx
+++ b/src/app/diaper/components/diaper-form.test.tsx
@@ -147,14 +147,18 @@ describe('DiaperForm', () => {
 	it('opens and closes the add product dialog', async () => {
 		render(<DiaperForm {...baseProps} />);
 
-		const plusButton = document.querySelector('.lucide-plus')?.closest('button');
+		const plusButton = document
+			.querySelector('.lucide-plus')
+			?.closest('button');
 		expect(plusButton).toBeTruthy();
 		fireEvent.click(plusButton!);
 
 		const dialog = await screen.findByRole('dialog', { name: /add product/i });
 		expect(dialog).toBeInTheDocument();
 
-		const cancelButton = within(dialog).getByRole('button', { name: /cancel/i });
+		const cancelButton = within(dialog).getByRole('button', {
+			name: /cancel/i,
+		});
 		fireEvent.click(cancelButton);
 
 		await waitFor(() => {


### PR DESCRIPTION
I identified `src/app/diaper/components/diaper-form.tsx` as the file with the lowest line coverage (75.43%) among source files. I added a new test case to `src/app/diaper/components/diaper-form.test.tsx` that exercises the "Add Product" dialog logic, which was previously uncovered. This increased the line coverage for the component to 78.94%. All tests passed, and no source code was modified.

---
*PR created automatically by Jules for task [7095864278389272287](https://jules.google.com/task/7095864278389272287) started by @clentfort*