### PR TITLE
Improve test coverage for store-utils.ts

### DIFF
--- a/src/lib/tinybase-sync/store-utils.test.ts
+++ b/src/lib/tinybase-sync/store-utils.test.ts
@@ -1,0 +1,41 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import {
+	STORE_VALUE_FEEDING_IN_PROGRESS,
+	STORE_VALUE_PROFILE,
+	TABLE_IDS,
+} from './constants';
+import { isStoreDataEmpty } from './store-utils';
+
+describe('isStoreDataEmpty', () => {
+	it('returns true for an empty store', () => {
+		const store = createStore();
+		expect(isStoreDataEmpty(store)).toBe(true);
+	});
+
+	it('returns false if any table has rows', () => {
+		for (const tableId of Object.values(TABLE_IDS)) {
+			const store = createStore();
+			store.setRow(tableId, 'row1', { cell1: 'value1' });
+			expect(isStoreDataEmpty(store)).toBe(false);
+		}
+	});
+
+	it('returns false if feedingInProgress is a string', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_FEEDING_IN_PROGRESS, 'session-id');
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+
+	it('returns true if feedingInProgress is not a string (e.g., undefined or boolean)', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_FEEDING_IN_PROGRESS, true as unknown as string);
+		expect(isStoreDataEmpty(store)).toBe(true);
+	});
+
+	it('returns false if profile exists', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_PROFILE, { name: 'Baby' });
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+});


### PR DESCRIPTION
Identified `src/lib/tinybase-sync/store-utils.ts` as one of the files with the lowest test coverage. Added a new test file `src/lib/tinybase-sync/store-utils.test.ts` with comprehensive test cases for the `isStoreDataEmpty` function, covering:
- Empty store state.
- Stores with rows in various tables.
- Stores with global values like `feedingInProgress` and `profile`.

Verified that the statement coverage for `store-utils.ts` reached 100%. Ensured no existing code was altered and no duplicate test files were created. Removed temporary coverage log files before submission. Passed linting and typechecking.

---
*PR created automatically by Jules for task [7238238050002581902](https://jules.google.com/task/7238238050002581902) started by @clentfort*