### PR TITLE
Improve test coverage for store-utils.ts

### DIFF
--- a/src/lib/tinybase-sync/store-utils.test.ts
+++ b/src/lib/tinybase-sync/store-utils.test.ts
@@ -1,0 +1,35 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import {
+	STORE_VALUE_FEEDING_IN_PROGRESS,
+	STORE_VALUE_PROFILE,
+	TABLE_IDS,
+} from './constants';
+import { isStoreDataEmpty } from './store-utils';
+
+describe('isStoreDataEmpty', () => {
+	it('returns true for an empty store', () => {
+		const store = createStore();
+		expect(isStoreDataEmpty(store)).toBe(true);
+	});
+
+	it('returns false if any table has rows', () => {
+		const store = createStore();
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, '1', {
+			timestamp: '2021-01-01T00:00:00Z',
+		});
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+
+	it('returns false if feeding in progress value is set', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_FEEDING_IN_PROGRESS, 'session-id');
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+
+	it('returns false if profile value is set', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_PROFILE, { name: 'Baby' });
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+});


### PR DESCRIPTION
I have improved the test coverage for `src/lib/tinybase-sync/store-utils.ts`, which was identified as one of the files with the lowest coverage (77.77%). By adding a new test file `src/lib/tinybase-sync/store-utils.test.ts`, I have reached 100% statement coverage for this module. All tests passed, and no regressions were introduced.

---
*PR created automatically by Jules for task [5544909252588424169](https://jules.google.com/task/5544909252588424169) started by @clentfort*