### PR TITLE
Improve test coverage for store-utils.ts

### DIFF
--- a/src/lib/tinybase-sync/store-utils.test.ts
+++ b/src/lib/tinybase-sync/store-utils.test.ts
@@ -1,0 +1,12 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import { STORE_VALUE_FEEDING_IN_PROGRESS } from './constants';
+import { isStoreDataEmpty } from './store-utils';
+
+describe('isStoreDataEmpty', () => {
+	it('returns false when feeding is in progress', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_FEEDING_IN_PROGRESS, '2026-03-27T10:00:00Z');
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+});


### PR DESCRIPTION
Identified `src/lib/tinybase-sync/store-utils.ts` as a file with low test coverage (77.77%). Added a single unit test to a new test file `src/lib/tinybase-sync/store-utils.test.ts` to cover the branch where `STORE_VALUE_FEEDING_IN_PROGRESS` is set, improving the file's line coverage to 88.88%. Verified that all project tests pass and no regressions were introduced.

---
*PR created automatically by Jules for task [3169244285473657516](https://jules.google.com/task/3169244285473657516) started by @clentfort*