### PR TITLE
Improve test coverage for store-utils.ts

### DIFF
--- a/src/lib/tinybase-sync/store-utils.test.ts
+++ b/src/lib/tinybase-sync/store-utils.test.ts
@@ -1,0 +1,33 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import {
+	STORE_VALUE_FEEDING_IN_PROGRESS,
+	STORE_VALUE_PROFILE,
+	TABLE_IDS,
+} from './constants';
+import { isStoreDataEmpty } from './store-utils';
+
+describe('isStoreDataEmpty', () => {
+	it('should return true when store is empty', () => {
+		const store = createStore();
+		expect(isStoreDataEmpty(store)).toBe(true);
+	});
+
+	it('should return false when store has table rows', () => {
+		const store = createStore();
+		store.setRow(TABLE_IDS.EVENTS, '1', { id: '1', notes: 'test' });
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+
+	it('should return false when store has feeding in progress value', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_FEEDING_IN_PROGRESS, '2025-01-01T00:00:00.000Z');
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+
+	it('should return false when store has profile value', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_PROFILE, 'some-profile-data');
+		expect(isStoreDataEmpty(store)).toBe(false);
+	});
+});


### PR DESCRIPTION
I have added a new test file `src/lib/tinybase-sync/store-utils.test.ts` to improve the test coverage of `src/lib/tinybase-sync/store-utils.ts`. 

The file previously had approximately 77.77% coverage due to several uncovered branches in the `isStoreDataEmpty` function. By adding specific test cases for empty stores, table rows, and global store values (feeding in progress and profile), I have brought the coverage of this module to 100%.

No existing code was altered during this process. All new tests pass, and the workspace has been cleaned of temporary coverage artifacts.

---
*PR created automatically by Jules for task [5176347257482950797](https://jules.google.com/task/5176347257482950797) started by @clentfort*