### PR TITLE
Improve test coverage for normalizeEntityStoreRowsMigration

### DIFF
--- a/src/migrations/2026-03-07-normalize-entity-store-rows.test.ts
+++ b/src/migrations/2026-03-07-normalize-entity-store-rows.test.ts
@@ -1,0 +1,20 @@
+import { createStore } from 'tinybase';
+import { describe, expect, it } from 'vitest';
+import { TABLE_IDS } from '@/lib/tinybase-sync/constants';
+import { normalizeEntityStoreRowsMigration } from './2026-03-07-normalize-entity-store-rows';
+
+describe('normalizeEntityStoreRowsMigration', () => {
+	it('deletes rows that fail validation (e.g., missing startDate)', () => {
+		const store = createStore();
+		// Set an invalid event (missing startDate)
+		store.setRow(TABLE_IDS.EVENTS, 'e1', {
+			title: 'Invalid Event',
+			type: 'point',
+		});
+
+		const result = normalizeEntityStoreRowsMigration.migrate(store);
+
+		expect(result).toBe(true);
+		expect(store.hasRow(TABLE_IDS.EVENTS, 'e1')).toBe(false);
+	});
+});


### PR DESCRIPTION
Added a new test file `src/migrations/2026-03-07-normalize-entity-store-rows.test.ts` to cover the row deletion branch in the `normalizeEntityStoreRowsMigration`. This increased line coverage for the target file from 77.77% to 94.44%.

---
*PR created automatically by Jules for task [13483747386045453062](https://jules.google.com/task/13483747386045453062) started by @clentfort*