### PR TITLE
Improve test coverage for normalize entity store rows migration

### DIFF
--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -183,6 +183,22 @@ describe('runMigrations', () => {
 		});
 	});
 
+	it('removes entity rows that fail schema validation', () => {
+		const store = createStore();
+		// Event without required startDate
+		store.setRow(TABLE_IDS.EVENTS, 'e1', {
+			title: 'Invalid Event',
+			type: 'point',
+		});
+
+		const result = runMigrations(store);
+
+		expect(result.appliedMigrationIds).toContain(
+			NORMALIZE_ENTITY_ROWS_MIGRATION_ID,
+		);
+		expect(store.hasRow(TABLE_IDS.EVENTS, 'e1')).toBe(false);
+	});
+
 	it('renames event description to notes', () => {
 		const store = createStore();
 		store.setRow(TABLE_IDS.EVENTS, 'e1', {


### PR DESCRIPTION
Improved test coverage for `src/migrations/2026-03-07-normalize-entity-store-rows.ts` by adding a test case to `src/migrations/index.test.ts`. The new test verifies that entity rows failing schema validation are correctly removed during migration. This increased the statement coverage for that file from 77.77% to 94.44%.

---
*PR created automatically by Jules for task [18436283819656237335](https://jules.google.com/task/18436283819656237335) started by @clentfort*