### PR TITLE
Improve BarChart test coverage

### DIFF
--- a/src/components/charts/bar-chart.test.tsx
+++ b/src/components/charts/bar-chart.test.tsx
@@ -211,4 +211,40 @@ describe('BarChart', () => {
 		expect(tickCallback(-15.5)).toBe('15.5h');
 		expect(tickCallback(10)).toBe('10h');
 	});
+
+	it('should return early if datasets become empty after initial mount', async () => {
+		const { rerender } = render(
+			<BarChart
+				datasets={[{ backgroundColor: 'red', data: [10], label: 'Set 1' }]}
+				emptyStateMessage="No data"
+				labels={['Day 1']}
+				title="Test Chart"
+				xAxisLabel="Days"
+				yAxisLabel="Hours"
+			/>,
+		);
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(mockChart).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<BarChart
+				datasets={[]}
+				emptyStateMessage="No data"
+				labels={['Day 1']}
+				title="Test Chart"
+				xAxisLabel="Days"
+				yAxisLabel="Hours"
+			/>,
+		);
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(screen.getByText('No data')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
I identified `src/components/charts/bar-chart.tsx` as the file with the lowest test coverage (78.37% statements). I added a single test case to `src/components/charts/bar-chart.test.tsx` that exercises an uncovered branch (line 63) by re-rendering the component with empty datasets after an initial successful mount. This increased the statement coverage to 79.72% and branch coverage from 54% to 55%. I verified the change by running the specific test file and the entire unit test suite.

---
*PR created automatically by Jules for task [10243866974264936189](https://jules.google.com/task/10243866974264936189) started by @clentfort*