### PR TITLE
Improve PieChart test coverage

### DIFF
--- a/src/components/charts/pie-chart.test.tsx
+++ b/src/components/charts/pie-chart.test.tsx
@@ -115,7 +115,11 @@ describe('PieChart', () => {
 		const labels = ['A', 'B'];
 
 		render(
-			<PieChart datasets={datasets} emptyStateMessage="No data" labels={labels} />,
+			<PieChart
+				datasets={datasets}
+				emptyStateMessage="No data"
+				labels={labels}
+			/>,
 		);
 
 		await act(async () => {

--- a/src/components/charts/pie-chart.test.tsx
+++ b/src/components/charts/pie-chart.test.tsx
@@ -107,4 +107,39 @@ describe('PieChart', () => {
 		expect(screen.getByText('No data to display')).toBeInTheDocument();
 		expect(screen.queryByRole('graphics-document')).not.toBeInTheDocument();
 	});
+
+	it('should exercise the default tooltip label formatter', async () => {
+		const datasets = [
+			{ backgroundColor: ['red', 'blue'], data: [10, 20], label: 'Set 1' },
+		];
+		const labels = ['A', 'B'];
+
+		render(
+			<PieChart datasets={datasets} emptyStateMessage="No data" labels={labels} />,
+		);
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		const chartConfig = mockChart.mock.calls[0][1] as {
+			options: {
+				plugins: {
+					tooltip: {
+						callbacks: {
+							label: (context: { label: string; parsed: number }) => string;
+						};
+					};
+				};
+			};
+		};
+
+		const labelFormatter = chartConfig.options.plugins.tooltip.callbacks.label;
+
+		// Test with label and parsed value
+		expect(labelFormatter({ label: 'A', parsed: 10 })).toBe('A: 10');
+
+		// Test with empty label
+		expect(labelFormatter({ label: '', parsed: 20 })).toBe('20');
+	});
 });


### PR DESCRIPTION
I identified `src/components/charts/pie-chart.tsx` as a high-priority candidate for coverage improvement (previously 79.54% statements). While `line-chart.tsx` had a slightly lower percentage, its remaining uncovered lines are largely unreachable in a unit test environment due to its instance management pattern.

I added a new test case to the existing `src/components/charts/pie-chart.test.tsx` file that manually invokes the default tooltip label formatter callback from the mocked Chart.js configuration. This covers the branching logic for both present and empty labels.

Verification:
- Run `pnpm vitest run src/components/charts/pie-chart.test.tsx --coverage`
- Result: 93.18% Statements (up from 79.54%)
- No source code was modified.

---
*PR created automatically by Jules for task [13690164437844421871](https://jules.google.com/task/13690164437844421871) started by @clentfort*