### PR TITLE
Improve PieChart test coverage

### DIFF
--- a/src/components/charts/pie-chart.test.tsx
+++ b/src/components/charts/pie-chart.test.tsx
@@ -107,4 +107,44 @@ describe('PieChart', () => {
 		expect(screen.getByText('No data to display')).toBeInTheDocument();
 		expect(screen.queryByRole('graphics-document')).not.toBeInTheDocument();
 	});
+
+	it('should use default tooltip label formatter when none is provided', async () => {
+		const datasets = [{ backgroundColor: ['red'], data: [10], label: 'Set 1' }];
+		const labels = ['A'];
+
+		render(
+			<PieChart
+				datasets={datasets}
+				emptyStateMessage="No data"
+				labels={labels}
+			/>,
+		);
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		const chartConfig = mockChart.mock.calls.at(-1)![1] as {
+			options: {
+				plugins: {
+					tooltip: {
+						callbacks: {
+							label: (context: {
+								label: string;
+								parsed: number | null;
+							}) => string;
+						};
+					};
+				};
+			};
+		};
+		const labelCallback = chartConfig.options.plugins.tooltip.callbacks.label;
+
+		// Test with label and value
+		expect(labelCallback({ label: 'A', parsed: 10 })).toBe('A: 10');
+		// Test without label
+		expect(labelCallback({ label: '', parsed: 10 })).toBe('10');
+		// Test without value
+		expect(labelCallback({ label: 'A', parsed: null })).toBe('A: ');
+	});
 });


### PR DESCRIPTION
This PR improves the unit test coverage for the `PieChart` component. 

By adding a targeted test case for the internal `tooltipLabelFormatter` callback, we've increased the statement coverage of `src/components/charts/pie-chart.tsx` from approximately 79.54% to 93.18%. The new test verifies the formatter's behavior with various combinations of labels and values, including edge cases with missing data.

Other files like `line-chart.tsx` and `bar-chart.tsx` also have low coverage, but their uncovered paths (internal chart updates) are currently unreachable in a unit test environment due to the chart instance being destroyed and recreated on every prop change. `PieChart` was selected as the highest-impact file with reachable but uncovered logic.

---
*PR created automatically by Jules for task [17202457482628876168](https://jules.google.com/task/17202457482628876168) started by @clentfort*