### PR TITLE
Improve test coverage for useSelectedProfileId hook

### DIFF
--- a/src/hooks/use-selected-profile-id.test.tsx
+++ b/src/hooks/use-selected-profile-id.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'tinybase';
+import { Provider } from 'tinybase/ui-react';
+import { describe, expect, it } from 'vitest';
+import { STORE_VALUE_SELECTED_PROFILE_ID } from '@/lib/tinybase-sync/constants';
+import { useSelectedProfileId } from './use-selected-profile-id';
+
+describe('useSelectedProfileId', () => {
+	it('should return undefined when no profile is selected', () => {
+		const store = createStore();
+		const wrapper = ({ children }: { children: React.ReactNode }) => (
+			<Provider store={store}>{children}</Provider>
+		);
+
+		const { result } = renderHook(() => useSelectedProfileId(), { wrapper });
+
+		expect(result.current[0]).toBeUndefined();
+	});
+
+	it('should return the selected profile ID from the store', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'test-profile');
+		const wrapper = ({ children }: { children: React.ReactNode }) => (
+			<Provider store={store}>{children}</Provider>
+		);
+
+		const { result } = renderHook(() => useSelectedProfileId(), { wrapper });
+
+		expect(result.current[0]).toBe('test-profile');
+	});
+
+	it('should update the selected profile ID in the store', () => {
+		const store = createStore();
+		const wrapper = ({ children }: { children: React.ReactNode }) => (
+			<Provider store={store}>{children}</Provider>
+		);
+
+		const { result } = renderHook(() => useSelectedProfileId(), { wrapper });
+
+		act(() => {
+			result.current[1]('new-profile');
+		});
+
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe('new-profile');
+		expect(result.current[0]).toBe('new-profile');
+	});
+});


### PR DESCRIPTION
Added a new unit test file for `use-selected-profile-id.ts` to improve its statement coverage from 80% to 100%. The test suite verifies the hook's ability to read from and write to the TinyBase store, ensuring correct multi-baby profile selection behavior. This addresses the request to improve coverage for low-coverage files without modifying existing source code.

---
*PR created automatically by Jules for task [15844010421213427961](https://jules.google.com/task/15844010421213427961) started by @clentfort*