### PR TITLE
Improve coverage for EntityFormDialog

### DIFF
--- a/src/components/form/entity-form-dialog.test.tsx
+++ b/src/components/form/entity-form-dialog.test.tsx
@@ -61,4 +61,35 @@ describe('EntityFormDialog', () => {
 		fireEvent.click(screen.getByText(/cancel/i));
 		expect(onClose).toHaveBeenCalled();
 	});
+
+	it('renders custom footer and handles onOpenChange', () => {
+		const onSave = vi.fn();
+		const onClose = vi.fn();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const form = { handleSubmit: vi.fn() } as any;
+
+		const { unmount } = render(
+			<EntityFormDialog
+				footer={<div data-testid="custom-footer">Custom Footer</div>}
+				form={form}
+				onClose={onClose}
+				onSave={onSave}
+				title="Custom Footer Dialog"
+			>
+				<div>Content</div>
+			</EntityFormDialog>,
+		);
+
+		expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
+
+		// Trigger onOpenChange(false) which should call onClose()
+		// Since Dialog is from @base-ui/react, we can try to trigger it via Escape key
+		fireEvent.keyDown(screen.getByRole('dialog'), {
+			code: 'Escape',
+			key: 'Escape',
+		});
+
+		expect(onClose).toHaveBeenCalled();
+		unmount();
+	});
 });


### PR DESCRIPTION
Improved test coverage for `src/components/form/entity-form-dialog.tsx` by adding a test case that covers the custom `footer` prop and the `onOpenChange` dialog callback. Statement coverage for this file is now 100%.

---
*PR created automatically by Jules for task [1774321073300173351](https://jules.google.com/task/1774321073300173351) started by @clentfort*