### PR TITLE
Improve test coverage for useGrowthMeasurement hook

### DIFF
--- a/src/hooks/use-growth-measurements.test.tsx
+++ b/src/hooks/use-growth-measurements.test.tsx
@@ -105,4 +105,26 @@ describe('useGrowthMeasurements', () => {
 			expect(result.current[0].id).toBe('g1');
 		});
 	});
+
+	describe('toGrowthMeasurement', () => {
+		it('should return null and log warning for invalid data', () => {
+			const store = createTestStore();
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			// Invalid: missing date (required in growthMeasurementSchema)
+			store.setRow(TABLE_IDS.GROWTH_MEASUREMENTS, 'g-invalid', {
+				weight: 3500,
+			});
+
+			const { result } = renderHook(() => useGrowthMeasurement('g-invalid'), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+
+			expect(result.current).toBeUndefined();
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+	});
 });


### PR DESCRIPTION
I have improved the test coverage for `src/hooks/use-growth-measurements.ts`. 

Initial analysis showed that while `line-chart.tsx` and `bar-chart.tsx` had slightly lower coverage, their uncovered paths were internal update logic that is currently unreachable in unit tests due to the component lifecycle. 

Instead, I targeted `use-growth-measurements.ts` (81.81% coverage), which had an uncovered branch in its data mapper for handling invalid records. I added a new test case to `src/hooks/use-growth-measurements.test.tsx` that injects a record with a missing required field (`date`) into the TinyBase store and verifies that the hook correctly returns `undefined` and logs a warning. This change brings the statement, branch, and line coverage for this file to 100%. 

All tests passed, and I've verified the coverage improvement with a local report.

---
*PR created automatically by Jules for task [3745767142763965930](https://jules.google.com/task/3745767142763965930) started by @clentfort*