### PR TITLE
Improve test coverage for useGrowthMeasurements hook

### DIFF
--- a/src/hooks/use-growth-measurements.test.tsx
+++ b/src/hooks/use-growth-measurements.test.tsx
@@ -86,6 +86,30 @@ describe('useGrowthMeasurements', () => {
 				weight: 3500,
 			});
 		});
+
+		it('should return undefined and log a warning for invalid data', () => {
+			const store = createTestStore();
+			// Missing required 'date' field
+			store.setRow(TABLE_IDS.GROWTH_MEASUREMENTS, 'g1', {
+				weight: 3500,
+			});
+
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const { result } = renderHook(() => useGrowthMeasurement('g1'), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+
+			expect(result.current).toBeUndefined();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid growth measurement data for id g1:'),
+				expect.any(Array),
+			);
+
+			consoleSpy.mockRestore();
+		});
 	});
 
 	describe('useGrowthMeasurementsSnapshot', () => {


### PR DESCRIPTION
I identified `src/hooks/use-growth-measurements.ts` as one of the functional files with the lowest test coverage (81.81%). While some chart components had lower nominal coverage, their uncovered paths (internal updates) are currently unreachable in unit tests due to their destructive `useEffect` cleanup pattern.

I added a new test case to `src/hooks/use-growth-measurements.test.tsx` that injects invalid data (a row missing the required `date` field) into the TinyBase store. This exercises the error-handling branch in the `toGrowthMeasurement` mapping function, bringing the hook to 100% statement, branch, function, and line coverage.

I also verified that all unit tests pass and that the codebase adheres to linting and formatting standards.

---
*PR created automatically by Jules for task [17145220416132162074](https://jules.google.com/task/17145220416132162074) started by @clentfort*