### PR TITLE
Improve test coverage for HistoryFilterIndicator

### DIFF
--- a/src/components/history-filter-indicator.test.tsx
+++ b/src/components/history-filter-indicator.test.tsx
@@ -52,4 +52,17 @@ describe('HistoryFilterIndicator', () => {
 			'border-left-color': 'var(--color-primary)',
 		});
 	});
+
+	it('returns null when isVisible is false', () => {
+		const { container } = render(
+			<HistoryFilterIndicator
+				baseUrl="/test-base"
+				from="2023-10-01T00:00:00.000Z"
+				isVisible={false}
+				to="2023-10-07T00:00:00.000Z"
+			/>,
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
 });


### PR DESCRIPTION
I identified `src/components/history-filter-indicator.tsx` as one of the components with lower test coverage (83.33% statements). I added a single test case to `src/components/history-filter-indicator.test.tsx` to cover the `isVisible={false}` branch, which was previously untested. This brought the component's coverage to 100% (Statements, Branches, Functions, and Lines).

While `LineChart` and `BarChart` have lower percentage coverage, they contain significant amounts of unreachable code in the current architecture (specifically the `chart.update()` path in `useEffect`), making them less suitable for a "single test" improvement without larger refactoring. `HistoryFilterIndicator` had a clear, reachable gap that I successfully closed.

---
*PR created automatically by Jules for task [17514097048925063500](https://jules.google.com/task/17514097048925063500) started by @clentfort*