### PR TITLE
Fix syntax errors in GitHub workflow files

### DIFF
--- a/.github/workflows/partykit-deploy-reusable.yaml
+++ b/.github/workflows/partykit-deploy-reusable.yaml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+        with:
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+        with:
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+        with:
           run_install: false
 
       - name: Install Node.js
@@ -75,6 +76,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+        with:
           run_install: false
 
       - name: Install Node.js


### PR DESCRIPTION
Fixed multiple syntax errors in GitHub workflow files by correctly nesting the `run_install` parameter under the `with:` key for the `pnpm/action-setup` action. This recurring error was present in `test.yaml`, `publish.yaml`, and `partykit-deploy-reusable.yaml`, preventing these workflows from executing. Verified the fixes by reviewing the file structure and running local linting/tests.

---
*PR created automatically by Jules for task [688562896879307974](https://jules.google.com/task/688562896879307974) started by @clentfort*