### PR TITLE
Improve test coverage for TotalFeedingsStats

### DIFF
--- a/src/app/statistics/components/total-feedings-stats.test.tsx
+++ b/src/app/statistics/components/total-feedings-stats.test.tsx
@@ -57,8 +57,11 @@ describe('TotalFeedingsStats', () => {
 		const statsCard = container.firstChild as HTMLElement;
 
 		// Total (4 vs 2) -> +100%
-		const primaryMetricContainer = within(statsCard).getByText('4').parentElement!;
-		expect(within(primaryMetricContainer).getByText(/100%/)).toBeInTheDocument();
+		const primaryMetricContainer =
+			within(statsCard).getByText('4').parentElement!;
+		expect(
+			within(primaryMetricContainer).getByText(/100%/),
+		).toBeInTheDocument();
 		expect(within(primaryMetricContainer).getByText(/↑/)).toBeInTheDocument();
 
 		// Left Breast (2 vs 1) -> +100%

--- a/src/app/statistics/components/total-feedings-stats.test.tsx
+++ b/src/app/statistics/components/total-feedings-stats.test.tsx
@@ -43,6 +43,39 @@ describe('TotalFeedingsStats', () => {
 		expect(within(rightBreastLabelDiv!).getByText('1')).toBeInTheDocument();
 	});
 
+	it('displays comparison values when comparisonSessions are provided', () => {
+		const comparisonSessions: FeedingSession[] = createFeedingSessions([
+			{ breast: 'left', durationInSeconds: 600 },
+			{ breast: 'right', durationInSeconds: 600 },
+		]);
+		const { container } = render(
+			<TotalFeedingsStats
+				comparisonSessions={comparisonSessions}
+				sessions={mockSessions}
+			/>,
+		);
+		const statsCard = container.firstChild as HTMLElement;
+
+		// Total (4 vs 2) -> +100%
+		const primaryMetricContainer = within(statsCard).getByText('4').parentElement!;
+		expect(within(primaryMetricContainer).getByText(/100%/)).toBeInTheDocument();
+		expect(within(primaryMetricContainer).getByText(/↑/)).toBeInTheDocument();
+
+		// Left Breast (2 vs 1) -> +100%
+		const leftBreastLabelDiv = within(statsCard)
+			.getByText(/Left Breast:/)
+			.closest('div')!;
+		expect(within(leftBreastLabelDiv).getByText(/100%/)).toBeInTheDocument();
+		expect(within(leftBreastLabelDiv).getByText(/↑/)).toBeInTheDocument();
+
+		// Right Breast (1 vs 1) -> 0%
+		// ComparisonValue returns null if change < 0.1%
+		const rightBreastLabelDiv = within(statsCard)
+			.getByText(/Right Breast:/)
+			.closest('div');
+		expect(within(rightBreastLabelDiv!).queryByText('%')).toBeNull();
+	});
+
 	it('handles sessions with only one breast type', () => {
 		const leftOnlySessions: FeedingSession[] = [
 			{ ...mockSessions[0], breast: 'left' },


### PR DESCRIPTION
I identified `src/app/statistics/components/total-feedings-stats.tsx` as a reachable target for coverage improvement. By adding a test case that provides the `comparisonSessions` prop, I exercised the logic for calculating and rendering percentage changes between current and previous feeding sessions. This improvement brings the component to 100% statement and line coverage.

I initially targeted `line-chart.tsx`, but found that its uncovered lines are currently unreachable in the unit test environment due to the chart instance being recreated rather than updated. I also ensured that no temporary diagnostic files (like `coverage_output.txt`) were included in the submission.

---
*PR created automatically by Jules for task [5725139624401685281](https://jules.google.com/task/5725139624401685281) started by @clentfort*