### PR TITLE
Improve test coverage for mergeStoreContent utility

### DIFF
--- a/src/lib/tinybase-sync/merge.test.ts
+++ b/src/lib/tinybase-sync/merge.test.ts
@@ -1,7 +1,7 @@
 import type { Content } from 'tinybase';
 import { createStore } from 'tinybase';
 import { describe, expect, it } from 'vitest';
-import { TABLE_IDS } from './constants';
+import { STORE_VALUE_SELECTED_PROFILE_ID, TABLE_IDS } from './constants';
 import { mergeStoreContent } from './merge';
 
 describe('mergeStoreContent', () => {
@@ -68,5 +68,33 @@ describe('mergeStoreContent', () => {
 		expect(store.getValue('existing')).toBe('value');
 		expect(store.getValue('empty')).toBe('filled');
 		expect(store.getValue('new')).toBe('added');
+	});
+
+	it('should handle selectedProfileId and empty snapshots correctly', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'local-profile');
+
+		const snapshot: Content = [
+			{},
+			{ [STORE_VALUE_SELECTED_PROFILE_ID]: 'remote-profile' },
+		];
+
+		// 1. Preserve local profile if non-empty
+		mergeStoreContent(store, snapshot, 'device1');
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe(
+			'local-profile',
+		);
+
+		// 2. Merge if local is empty
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, '');
+		mergeStoreContent(store, snapshot, 'device1');
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe(
+			'remote-profile',
+		);
+
+		// 3. Handle empty snapshots
+		// @ts-ignore
+		mergeStoreContent(store, [undefined, undefined], 'device1');
+		expect(store.hasValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe(true);
 	});
 });


### PR DESCRIPTION
This PR improves the test coverage for `src/lib/tinybase-sync/merge.ts` from ~83.33% to 100% by adding a single comprehensive test case to the existing test suite.

The added test case exercises the following logic:
- Preservation of the local active profile ID (`selectedProfileId`) during data merges.
- Conditional merging of the active profile ID if it is unset or empty locally.
- Graceful handling of empty or undefined snapshots during synchronization.

Lower-coverage files like `LineChart.tsx` (78.64%) and `BarChart.tsx` (79.72%) were evaluated but found to contain unreachable code paths (such as `chart.update()` inside `useEffect` with destructive cleanup) that cannot be covered in unit tests without modifying the source code, which was restricted by the task requirements. Thus, `merge.ts` was selected as the most impactful target for coverage improvement.

---
*PR created automatically by Jules for task [18071536758334593593](https://jules.google.com/task/18071536758334593593) started by @clentfort*