### PR TITLE
Improve test coverage for mergeStoreContent utility

### DIFF
--- a/src/lib/tinybase-sync/merge.test.ts
+++ b/src/lib/tinybase-sync/merge.test.ts
@@ -113,7 +113,10 @@ describe('mergeStoreContent', () => {
 	it('should handle snapshots without tables or values', () => {
 		const store = createStore();
 		// Snapshot with undefined tables and values
-		const snapshot: Content = [undefined as any, undefined as any];
+		const snapshot: Content = [
+			undefined as unknown as Content[0],
+			undefined as unknown as Content[1],
+		];
 
 		expect(() => mergeStoreContent(store, snapshot, 'device1')).not.toThrow();
 	});

--- a/src/lib/tinybase-sync/merge.test.ts
+++ b/src/lib/tinybase-sync/merge.test.ts
@@ -1,7 +1,7 @@
 import type { Content } from 'tinybase';
 import { createStore } from 'tinybase';
 import { describe, expect, it } from 'vitest';
-import { TABLE_IDS } from './constants';
+import { STORE_VALUE_SELECTED_PROFILE_ID, TABLE_IDS } from './constants';
 import { mergeStoreContent } from './merge';
 
 describe('mergeStoreContent', () => {
@@ -68,5 +68,53 @@ describe('mergeStoreContent', () => {
 		expect(store.getValue('existing')).toBe('value');
 		expect(store.getValue('empty')).toBe('filled');
 		expect(store.getValue('new')).toBe('added');
+	});
+
+	it('should preserve local selectedProfileId if already set', () => {
+		const store = createStore();
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'local-id');
+
+		const snapshot: Content = [
+			{},
+			{
+				[STORE_VALUE_SELECTED_PROFILE_ID]: 'remote-id',
+			},
+		];
+
+		mergeStoreContent(store, snapshot, 'device1');
+
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe('local-id');
+	});
+
+	it('should merge selectedProfileId if local is missing or empty', () => {
+		const store = createStore();
+		// Case 1: Missing
+		let snapshot: Content = [
+			{},
+			{
+				[STORE_VALUE_SELECTED_PROFILE_ID]: 'remote-id-1',
+			},
+		];
+		mergeStoreContent(store, snapshot, 'device1');
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe('remote-id-1');
+
+		// Case 2: Empty string
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, '');
+		snapshot = [
+			{},
+			{
+				[STORE_VALUE_SELECTED_PROFILE_ID]: 'remote-id-2',
+			},
+		];
+		mergeStoreContent(store, snapshot, 'device1');
+		expect(store.getValue(STORE_VALUE_SELECTED_PROFILE_ID)).toBe('remote-id-2');
+	});
+
+	it('should handle snapshots without tables or values', () => {
+		const store = createStore();
+		// Snapshot with undefined tables and values
+		const snapshot: Content = [undefined as any, undefined as any];
+
+		expect(() => mergeStoreContent(store, snapshot, 'device1')).not.toThrow();
 	});
 });


### PR DESCRIPTION
I identified `src/lib/tinybase-sync/merge.ts` as a file with reachable uncovered branches (initially 83.33% statement coverage). I added tests to `src/lib/tinybase-sync/merge.test.ts` that cover:
- Preserving a local `selectedProfileId` if it is already set.
- Merging a remote `selectedProfileId` if the local one is missing or empty.
- Handling snapshots with undefined tables or values.

These changes bring `merge.ts` to 100% statement and branch coverage.

---
*PR created automatically by Jules for task [12344077630831720899](https://jules.google.com/task/12344077630831720899) started by @clentfort*