### PR TITLE
Configure Renovate minimumReleaseAge to match pnpm 11

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
+	"minimumReleaseAge": "1 day",
+	"internalChecksFilter": "strict",
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true


### PR DESCRIPTION
This PR configures Renovate to match pnpm 11's security-focused package update policy.

Key changes:
- Added `minimumReleaseAge: "1 day"` to `renovate.json` (equivalent to pnpm 11's 1440-minute default).
- Added `internalChecksFilter: "strict"` to ensure Renovate doesn't create branches or PRs for packages that haven't passed the cooldown period yet, which is the recommended configuration for this feature.

These changes were validated using `renovate-config-validator` and project-wide quality checks (`lint` and `test:unit`).

---
*PR created automatically by Jules for task [5310515075658893409](https://jules.google.com/task/5310515075658893409) started by @clentfort*