### PR TITLE
Improve test coverage for use-profile.ts

### DIFF
--- a/src/hooks/use-profile.test.tsx
+++ b/src/hooks/use-profile.test.tsx
@@ -56,7 +56,10 @@ describe('useProfile', () => {
 
 		act(() => {
 			// 'sex' must be 'boy' or 'girl', so 'invalid' will fail validation
-			store.setRow(TABLE_IDS.PROFILES, 'p1', { name: 'Invalid', sex: 'invalid' });
+			store.setRow(TABLE_IDS.PROFILES, 'p1', {
+				name: 'Invalid',
+				sex: 'invalid',
+			});
 			store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'p1');
 		});
 

--- a/src/hooks/use-profile.test.tsx
+++ b/src/hooks/use-profile.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	STORE_VALUE_SELECTED_PROFILE_ID,
 	TABLE_IDS,
@@ -42,5 +42,30 @@ describe('useProfile', () => {
 		expect(store.getRow(TABLE_IDS.PROFILES, 'p1')).toMatchObject({
 			name: 'Baby Ada',
 		});
+	});
+
+	it('should handle invalid profile data and return null', () => {
+		const store = createTestStore();
+		const { result } = renderHook(() => useProfile(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		act(() => {
+			// 'sex' must be 'boy' or 'girl', so 'invalid' will fail validation
+			store.setRow(TABLE_IDS.PROFILES, 'p1', { name: 'Invalid', sex: 'invalid' });
+			store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'p1');
+		});
+
+		expect(result.current[0]).toBeNull();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Invalid profile data for id p1:'),
+			expect.any(Array),
+		);
+
+		warnSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
I have improved the test coverage for `src/hooks/use-profile.ts` by adding a new test case to `src/hooks/use-profile.test.tsx`. 

While `src/components/charts/line-chart.tsx` and `src/components/charts/bar-chart.tsx` currently show lower coverage, their uncovered paths are effectively unreachable in the current unit test environment due to the chart instance being destroyed and recreated on every prop change. Improving coverage for those files would require architectural changes to the components themselves, which was prohibited by the "DO NOT ALTER CODE" constraint.

The new test case for `use-profile.ts` simulates invalid data in the TinyBase store (e.g., an invalid enum value for `sex`), which triggers the `console.warn` and returns `null` in the `toProfile` mapper. This branch was previously uncovered.

Verified:
- `src/hooks/use-profile.ts` now has 100% coverage (Statements/Branches/Functions/Lines).
- All 407 unit tests passed.
- Code review received a "Correct" rating.

---
*PR created automatically by Jules for task [657999465248337189](https://jules.google.com/task/657999465248337189) started by @clentfort*