### PR TITLE
Allow independent unit system switching

### DIFF
--- a/src/app/diaper/components/diaper-form.tsx
+++ b/src/app/diaper/components/diaper-form.tsx
@@ -191,7 +191,7 @@ export default function DiaperForm({
 	title,
 	...props
 }: DiaperFormProps) {
-	const unitSystem = useUnitSystem();
+	const [unitSystem] = useUnitSystem();
 	const isImperial = unitSystem === 'imperial';
 	const upsertProduct = useUpsertDiaperProduct();
 	const changes = useDiaperChangesSnapshot();

--- a/src/app/diaper/components/diaper-history-list.tsx
+++ b/src/app/diaper/components/diaper-history-list.tsx
@@ -47,7 +47,7 @@ function DiaperHistoryEntry({
 	onEdit: (changeId: string) => void;
 }) {
 	const change = useDiaperChange(changeId);
-	const unitSystem = useUnitSystem();
+	const [unitSystem] = useUnitSystem();
 	const isImperial = unitSystem === 'imperial';
 
 	if (!change) {

--- a/src/app/growth/components/growth-form.test.tsx
+++ b/src/app/growth/components/growth-form.test.tsx
@@ -8,7 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import MeasurementForm from './growth-form';
 
-const mockUseUnitSystem = vi.fn(() => 'metric');
+const mockUseUnitSystem = vi.fn(() => ['metric', vi.fn()]);
 
 vi.mock('@/hooks/use-unit-system', () => ({
 	useUnitSystem: () => mockUseUnitSystem(),
@@ -33,7 +33,7 @@ describe('MeasurementForm', () => {
 	});
 
 	it('renders correctly and calls onSave with numeric data when submitted', async () => {
-		mockUseUnitSystem.mockReturnValue('metric');
+		mockUseUnitSystem.mockReturnValue(['metric', vi.fn()]);
 		render(<MeasurementForm {...baseProps} />);
 
 		const weightInput = screen.getByLabelText(/weight \(g\)/i);
@@ -60,7 +60,7 @@ describe('MeasurementForm', () => {
 	});
 
 	it('converts correctly between metric and imperial units', async () => {
-		mockUseUnitSystem.mockReturnValue('imperial');
+		mockUseUnitSystem.mockReturnValue(['imperial', vi.fn()]);
 
 		const existingMeasurement = {
 			date: '2025-01-01T12:00:00Z',

--- a/src/app/growth/components/growth-form.tsx
+++ b/src/app/growth/components/growth-form.tsx
@@ -56,7 +56,7 @@ export default function MeasurementForm({
 	...props
 }: MeasurementFormProps) {
 	const measurement = 'measurement' in props ? props.measurement : undefined;
-	const unitSystem = useUnitSystem();
+	const [unitSystem] = useUnitSystem();
 	const isImperial = unitSystem === 'imperial';
 
 	const defaultValues = useMemo(() => {

--- a/src/app/growth/components/indexed-growth-history-list.tsx
+++ b/src/app/growth/components/indexed-growth-history-list.tsx
@@ -46,7 +46,7 @@ function GrowthHistoryEntry({
 }: GrowthHistoryEntryProps) {
 	const measurement = useGrowthMeasurement(rowId);
 	const { locale } = useLanguage();
-	const unitSystem = useUnitSystem();
+	const [unitSystem] = useUnitSystem();
 	const isImperial = unitSystem === 'imperial';
 
 	if (!measurement) return null;

--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { fbt } from 'fbtee';
-import { Coins, Globe, LayoutGrid, Moon } from 'lucide-react';
+import { Coins, Globe, LayoutGrid, Moon, Ruler } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -17,6 +17,7 @@ import { useLanguage } from '@/contexts/i18n-context';
 import { Currency, useCurrency } from '@/hooks/use-currency';
 import { useDevMode } from '@/hooks/use-dev-mode';
 import { useShowComparisonCharts } from '@/hooks/use-show-comparison-charts';
+import { useUnitSystem } from '@/hooks/use-unit-system';
 import { useShowFeeding } from '@/hooks/use-show-feeding';
 import { Locale } from '@/i18n';
 import { SettingsHeader } from '../components/settings-header';
@@ -24,6 +25,7 @@ import { SettingsHeader } from '../components/settings-header';
 export default function AppearanceSettingsPage() {
 	const { setTheme, theme } = useTheme();
 	const { locale, setLocale } = useLanguage();
+	const [unitSystem, setUnitSystem] = useUnitSystem();
 	const [currency, setCurrency] = useCurrency();
 	const [devMode, setDevMode] = useDevMode();
 	const [showComparisonCharts, setShowComparisonCharts] =
@@ -64,6 +66,35 @@ export default function AppearanceSettingsPage() {
 								<SelectContent>
 									<SelectItem value="de-DE">German</SelectItem>
 									<SelectItem value="en-US">English</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-2">
+							<div className="flex items-center gap-2">
+								<Ruler className="h-4 w-4" />
+								<p className="text-sm font-medium">
+									<fbt desc="Label for unit system setting">Unit System</fbt>
+								</p>
+							</div>
+							<Select
+								onValueChange={(v) => {
+									if (v) {
+										setUnitSystem(v as 'metric' | 'imperial');
+									}
+								}}
+								value={unitSystem}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="metric">
+										<fbt desc="Metric unit system option">Metric</fbt>
+									</SelectItem>
+									<SelectItem value="imperial">
+										<fbt desc="Imperial unit system option">Imperial</fbt>
+									</SelectItem>
 								</SelectContent>
 							</Select>
 						</div>

--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -17,8 +17,8 @@ import { useLanguage } from '@/contexts/i18n-context';
 import { Currency, useCurrency } from '@/hooks/use-currency';
 import { useDevMode } from '@/hooks/use-dev-mode';
 import { useShowComparisonCharts } from '@/hooks/use-show-comparison-charts';
-import { useUnitSystem } from '@/hooks/use-unit-system';
 import { useShowFeeding } from '@/hooks/use-show-feeding';
+import { useUnitSystem } from '@/hooks/use-unit-system';
 import { Locale } from '@/i18n';
 import { SettingsHeader } from '../components/settings-header';
 

--- a/src/app/statistics/components/growth-chart.test.tsx
+++ b/src/app/statistics/components/growth-chart.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/hooks/use-profile', () => ({
 }));
 
 vi.mock('@/hooks/use-unit-system', () => ({
-	useUnitSystem: () => 'metric',
+	useUnitSystem: () => ['metric', vi.fn()],
 }));
 
 vi.mock('@/utils/growth-standards', () => ({

--- a/src/app/statistics/components/growth-chart.tsx
+++ b/src/app/statistics/components/growth-chart.tsx
@@ -124,7 +124,7 @@ function calculateGrowthData(
 
 export default function GrowthChart({ measurements = [] }: GrowthChartProps) {
 	const [profile] = useProfile();
-	const unitSystem = useUnitSystem();
+	const [unitSystem] = useUnitSystem();
 	const isImperial = unitSystem === 'imperial';
 	const [weightRange, setWeightRange] = useState<RangePoint[]>([]);
 	const [heightRange, setHeightRange] = useState<RangePoint[]>([]);

--- a/src/hooks/use-unit-system.test.tsx
+++ b/src/hooks/use-unit-system.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { createStore } from 'tinybase';
 import { Provider } from 'tinybase/ui-react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { I18nProvider } from '@/contexts/i18n-context';
 import { useUnitSystem } from './use-unit-system';
 
@@ -30,9 +30,4 @@ describe('useUnitSystem', () => {
 
 		expect(result.current[0]).toBe('metric');
 	});
-
-    it('should persist unit system regardless of locale once set', async () => {
-        // This test might be tricky because I18nProvider might need to be re-rendered with a different locale
-        // But the unit system is stored in TinyBase, which is what we want to verify.
-    });
 });

--- a/src/hooks/use-unit-system.test.tsx
+++ b/src/hooks/use-unit-system.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'tinybase';
+import { Provider } from 'tinybase/ui-react';
+import { describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '@/contexts/i18n-context';
+import { useUnitSystem } from './use-unit-system';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+	const store = createStore();
+	return (
+		<Provider store={store}>
+			<I18nProvider>{children}</I18nProvider>
+		</Provider>
+	);
+};
+
+describe('useUnitSystem', () => {
+	it('should return default unit system based on locale', () => {
+		const { result } = renderHook(() => useUnitSystem(), { wrapper });
+		// Default locale is en-US, so it should be imperial
+		expect(result.current[0]).toBe('imperial');
+	});
+
+	it('should allow updating unit system', () => {
+		const { result } = renderHook(() => useUnitSystem(), { wrapper });
+
+		act(() => {
+			result.current[1]('metric');
+		});
+
+		expect(result.current[0]).toBe('metric');
+	});
+
+    it('should persist unit system regardless of locale once set', async () => {
+        // This test might be tricky because I18nProvider might need to be re-rendered with a different locale
+        // But the unit system is stored in TinyBase, which is what we want to verify.
+    });
+});

--- a/src/hooks/use-unit-system.ts
+++ b/src/hooks/use-unit-system.ts
@@ -6,7 +6,9 @@ export type UnitSystem = 'imperial' | 'metric';
 
 export function useUnitSystem() {
 	const { locale } = useLanguage();
-	const unitSystem = useValue(STORE_VALUE_UNIT_SYSTEM) as UnitSystem | undefined;
+	const unitSystem = useValue(STORE_VALUE_UNIT_SYSTEM) as
+		| UnitSystem
+		| undefined;
 
 	const setUnitSystem = useSetValueCallback(
 		STORE_VALUE_UNIT_SYSTEM,
@@ -14,7 +16,8 @@ export function useUnitSystem() {
 		[],
 	);
 
-	const defaultUnitSystem: UnitSystem = locale === 'en-US' ? 'imperial' : 'metric';
+	const defaultUnitSystem: UnitSystem =
+		locale === 'en-US' ? 'imperial' : 'metric';
 
 	return [unitSystem ?? defaultUnitSystem, setUnitSystem] as const;
 }

--- a/src/hooks/use-unit-system.ts
+++ b/src/hooks/use-unit-system.ts
@@ -1,8 +1,20 @@
+import { useSetValueCallback, useValue } from 'tinybase/ui-react';
 import { useLanguage } from '@/contexts/i18n-context';
+import { STORE_VALUE_UNIT_SYSTEM } from '@/lib/tinybase-sync/constants';
 
 export type UnitSystem = 'imperial' | 'metric';
 
-export function useUnitSystem(): UnitSystem {
+export function useUnitSystem() {
 	const { locale } = useLanguage();
-	return locale === 'en-US' ? 'imperial' : 'metric';
+	const unitSystem = useValue(STORE_VALUE_UNIT_SYSTEM) as UnitSystem | undefined;
+
+	const setUnitSystem = useSetValueCallback(
+		STORE_VALUE_UNIT_SYSTEM,
+		(newUnitSystem: UnitSystem) => newUnitSystem,
+		[],
+	);
+
+	const defaultUnitSystem: UnitSystem = locale === 'en-US' ? 'imperial' : 'metric';
+
+	return [unitSystem ?? defaultUnitSystem, setUnitSystem] as const;
 }

--- a/src/lib/tinybase-sync/constants.ts
+++ b/src/lib/tinybase-sync/constants.ts
@@ -8,6 +8,7 @@ export const STORE_VALUE_FEEDING_IN_PROGRESS = 'feedingInProgress';
 export const STORE_VALUE_PROFILE = 'profile';
 export const STORE_VALUE_SELECTED_PROFILE_ID = 'selectedProfileId';
 export const STORE_VALUE_SHOW_FEEDING = 'showFeeding';
+export const STORE_VALUE_UNIT_SYSTEM = 'unitSystem';
 
 export const TABLE_IDS = {
 	DIAPER_CHANGES: 'diaperChanges',


### PR DESCRIPTION
This change allows users to manually select their preferred unit system (Metric or Imperial) in the Appearance settings, regardless of their current language/locale setting. The preference is persisted in the TinyBase store.

Key changes:
- `src/lib/tinybase-sync/constants.ts`: Added `STORE_VALUE_UNIT_SYSTEM`.
- `src/hooks/use-unit-system.ts`: Modified to return `[unitSystem, setUnitSystem]` and use TinyBase for persistence.
- `src/app/settings/appearance/page.tsx`: Added a "Unit System" selector.
- Updated multiple components in `src/app/growth`, `src/app/diaper`, and `src/app/statistics` to accommodate the hook's new return type.
- Updated existing tests and added new unit tests for `useUnitSystem`.

---
*PR created automatically by Jules for task [3791518732646971068](https://jules.google.com/task/3791518732646971068) started by @clentfort*