### PR TITLE
Improve test coverage for createEntityHooks

### DIFF
--- a/src/hooks/create-entity-hooks.test.tsx
+++ b/src/hooks/create-entity-hooks.test.tsx
@@ -130,4 +130,189 @@ describe('createEntityHooks', () => {
 			expect(result.current).toEqual(['1', '2']);
 		});
 	});
+
+	describe('multi-profile isolation', () => {
+		it('should handle profile-based filtering and injection', () => {
+			const store = createTestStore();
+			// Set a selected profile ID in values
+			store.setValue('selectedProfileId', 'profile-1');
+
+			// 1. useUpsert should inject profileId
+			const { result: upsertResult } = renderHook(() => testHooks.useUpsert(), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+			act(() => {
+				upsertResult.current({ id: 'e1', name: 'Entity 1' });
+			});
+			expect(store.getRow(TABLE_ID, 'e1')).toEqual({
+				deviceId: 'test-device-id',
+				name: 'Entity 1',
+				profileId: 'profile-1',
+			});
+
+			// 2. useOne should return undefined for mismatched profile
+			store.setRow(TABLE_ID, 'e2', {
+				name: 'Entity 2',
+				profileId: 'profile-2',
+			});
+			const { result: oneResult } = renderHook(() => testHooks.useOne('e2'), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+			expect(oneResult.current).toBeUndefined();
+
+			// 3. useSnapshot should filter by profile
+			const { result: snapshotResult } = renderHook(
+				() => testHooks.useSnapshot(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(snapshotResult.current).toEqual([{ id: 'e1', name: 'Entity 1' }]);
+
+			// 4. useIds should filter by profile
+			const { result: idsResult } = renderHook(() => testHooks.useIds(), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+			expect(idsResult.current).toEqual(['e1']);
+
+			// 5. PROFILES table special case for useSnapshot (should not filter)
+			const profilesHooks = createEntityHooks<TestEntity>({
+				sanitize,
+				tableId: 'profiles',
+				toEntity,
+			});
+			store.setRow('profiles', 'p1', { name: 'Profile 1' });
+			store.setRow('profiles', 'p2', { name: 'Profile 2' });
+			const { result: profilesSnapshotResult } = renderHook(
+				() => profilesHooks.useSnapshot(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(profilesSnapshotResult.current).toHaveLength(2);
+
+			// 6. Handle null return from sanitize or mapping
+			const nullHooks = createEntityHooks<TestEntity>({
+				sanitize: () => null,
+				tableId: 'null_table',
+				toEntity: () => null,
+			});
+			const { result: nullUpsertResult } = renderHook(
+				() => nullHooks.useUpsert(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			act(() => {
+				nullUpsertResult.current({ id: 'null-id', name: 'Null' });
+			});
+			expect(store.getRow('null_table', 'null-id')).toEqual({});
+
+			// Ensure the row has the correct profileId to reach line 72 in useOne
+			store.setRow('null_table', 'null-id', {
+				name: 'Null',
+				profileId: 'profile-1',
+			});
+			const { result: nullOneResult } = renderHook(
+				() => nullHooks.useOne('null-id'),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(nullOneResult.current).toBeUndefined();
+
+			const { result: nullSnapshotResult } = renderHook(
+				() => nullHooks.useSnapshot(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(nullSnapshotResult.current).toEqual([]);
+
+			// 7. useOne with undefined ID
+			const { result: undefinedOneResult } = renderHook(
+				() => testHooks.useOne(undefined),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(undefinedOneResult.current).toBeUndefined();
+
+			// 8. useIds for PROFILES table
+			const { result: profilesIdsResult } = renderHook(
+				() => profilesHooks.useIds(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(profilesIdsResult.current).toEqual(['p1', 'p2']);
+
+			// 9. No profile selected
+			const newStore = createTestStore();
+			newStore.setRow(TABLE_ID, 'e1', { name: 'E1' });
+			newStore.setRow(TABLE_ID, 'e2', { name: 'E2' });
+
+			const { result: noProfileIdsResult } = renderHook(
+				() => testHooks.useIds(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={newStore}>
+							{children}
+						</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(noProfileIdsResult.current).toEqual(['e1', 'e2']);
+
+			// 10. useUpsert for PROFILES table (should NOT inject profileId)
+			const { result: profilesUpsertResult } = renderHook(
+				() => profilesHooks.useUpsert(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+					),
+				},
+			);
+			act(() => {
+				profilesUpsertResult.current({ id: 'p3', name: 'Profile 3' });
+			});
+			expect(store.getRow('profiles', 'p3')).toEqual({
+				deviceId: 'test-device-id',
+				name: 'Profile 3',
+			});
+
+			// 11. useSnapshot with no profile selected
+			const { result: noProfileSnapshotResult } = renderHook(
+				() => testHooks.useSnapshot(),
+				{
+					wrapper: ({ children }) => (
+						<TinyBaseTestWrapper store={newStore}>
+							{children}
+						</TinyBaseTestWrapper>
+					),
+				},
+			);
+			expect(noProfileSnapshotResult.current).toHaveLength(2);
+		});
+	});
 });


### PR DESCRIPTION
I identified `src/hooks/create-entity-hooks.ts` as one of the files with the lowest test coverage (85.71% statements) that had reachable uncovered paths. I added a single comprehensive test case to `src/hooks/create-entity-hooks.test.tsx` that exercises multiple logic branches, including:
- Profile ID injection in `useUpsert`.
- Profile mismatch handling in `useOne`.
- Profile filtering in `useSnapshot` and `useIds`.
- The special case for the `PROFILES` table in `useSnapshot` and `useIds`.
- Handling of `null` returns from sanitization and mapping functions.

The change brings the statement, branch, function, and line coverage for `src/hooks/create-entity-hooks.ts` to 100%. All unit tests passed.

---
*PR created automatically by Jules for task [9574552669300789473](https://jules.google.com/task/9574552669300789473) started by @clentfort*