### PR TITLE
Improve coverage for diaper store normalization migration

### DIFF
--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -187,6 +187,22 @@ describe('runMigrations', () => {
 		});
 	});
 
+	it('removes invalid diaper changes during normalization', () => {
+		const store = createStore();
+		// Missing required 'timestamp'
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'invalid-d1', {
+			containsStool: false,
+			containsUrine: true,
+		});
+
+		const result = runMigrations(store);
+
+		expect(result.appliedMigrationIds).toContain(
+			NORMALIZE_DIAPER_ROWS_MIGRATION_ID,
+		);
+		expect(store.hasRow(TABLE_IDS.DIAPER_CHANGES, 'invalid-d1')).toBe(false);
+	});
+
 	it('renames event description to notes', () => {
 		const store = createStore();
 		store.setRow(TABLE_IDS.EVENTS, 'e1', {


### PR DESCRIPTION
Added a test case to verify that invalid rows are correctly deleted during the diaper store normalization migration. This improved the coverage for `src/migrations/2026-03-07-normalize-diaper-store-rows.ts` from 85.71% to 100%.

---
*PR created automatically by Jules for task [17064067486137443428](https://jules.google.com/task/17064067486137443428) started by @clentfort*