### PR TITLE
Add persistent time format setting (12h/24h)

### DIFF
--- a/src/app/diaper/components/diaper-history-list.tsx
+++ b/src/app/diaper/components/diaper-history-list.tsx
@@ -12,6 +12,7 @@ import {
 	useUpsertDiaperChange,
 } from '@/hooks/use-diaper-changes';
 import { useHistoryRange } from '@/hooks/use-history-range';
+import { useTimeFormat } from '@/hooks/use-time-format';
 import { useDiaperChangesByDate } from '@/hooks/use-tinybase-indexes';
 import { useUnitSystem } from '@/hooks/use-unit-system';
 import { TABLE_IDS } from '@/lib/tinybase-sync/constants';
@@ -48,6 +49,7 @@ function DiaperHistoryEntry({
 }) {
 	const change = useDiaperChange(changeId);
 	const [unitSystem] = useUnitSystem();
+	const [timeFormat] = useTimeFormat();
 	const isImperial = unitSystem === 'imperial';
 
 	if (!change) {
@@ -70,7 +72,12 @@ function DiaperHistoryEntry({
 			data-testid="diaper-history-entry"
 			formattedTime={
 				<div className="flex items-center gap-2">
-					<span>{formatEntryTime(change.timestamp)}</span>
+					<span>
+						{formatEntryTime(
+							change.timestamp,
+							timeFormat === '24h' ? 'HH:mm' : 'p',
+						)}
+					</span>
 					{change.temperature && (
 						<>
 							<span className="mx-1">•</span>

--- a/src/app/feeding/components/feeding-history-list.tsx
+++ b/src/app/feeding/components/feeding-history-list.tsx
@@ -8,6 +8,7 @@ import IndexedHistoryList from '@/components/indexed-history-list';
 import { BREAST_COLORS } from '@/constants/colors';
 import { useFeedingSession } from '@/hooks/use-feeding-sessions';
 import { useHistoryRange } from '@/hooks/use-history-range';
+import { useTimeFormat } from '@/hooks/use-time-format';
 import { useFeedingSessionsByDate } from '@/hooks/use-tinybase-indexes';
 import { formatDurationAbbreviated } from '@/utils/format-duration-abbreviated';
 import { formatEntryTime } from '@/utils/format-history-date';
@@ -28,6 +29,7 @@ function FeedingHistoryEntry({
 	sessionId: string;
 }) {
 	const session = useFeedingSession(sessionId);
+	const [timeFormat] = useTimeFormat();
 
 	if (!session) {
 		return null;
@@ -43,7 +45,14 @@ function FeedingHistoryEntry({
 		<HistoryEntryCard
 			accentColor={accentColor}
 			data-testid="feeding-history-entry"
-			formattedTime={<span>{formatEntryTime(session.startTime)}</span>}
+			formattedTime={
+				<span>
+					{formatEntryTime(
+						session.startTime,
+						timeFormat === '24h' ? 'HH:mm' : 'p',
+					)}
+				</span>
+			}
 			header={
 				<span>
 					{isLeftBreast ? (

--- a/src/app/feeding/components/feeding-tracker.tsx
+++ b/src/app/feeding/components/feeding-tracker.tsx
@@ -187,7 +187,8 @@ export default function BreastfeedingTracker({
 										<fbt desc="Label indicating the start time of the current feeding session">
 											Start
 										</fbt>
-										: {format(
+										:{' '}
+										{format(
 											feedingInProgress.startTime,
 											timeFormat === '24h' ? 'HH:mm' : 'p',
 										)}

--- a/src/app/feeding/components/feeding-tracker.tsx
+++ b/src/app/feeding/components/feeding-tracker.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useFeedingInProgress } from '@/hooks/use-feeding-in-progress';
+import { useTimeFormat } from '@/hooks/use-time-format';
 import { formatDurationShort } from '@/utils/format-duration-short';
 import FeedingForm from './feeding-form';
 
@@ -26,6 +27,7 @@ export default function BreastfeedingTracker({
 	);
 	const timerRef = useRef<NodeJS.Timeout | null>(null);
 	const [feedingInProgress, setFeedingInProgress] = useFeedingInProgress();
+	const [timeFormat] = useTimeFormat();
 	const [resumedSessionOriginalId, setResumedSessionOriginalId] = useState<
 		string | null
 	>(null);
@@ -185,7 +187,10 @@ export default function BreastfeedingTracker({
 										<fbt desc="Label indicating the start time of the current feeding session">
 											Start
 										</fbt>
-										: {format(feedingInProgress.startTime, 'p')}
+										: {format(
+											feedingInProgress.startTime,
+											timeFormat === '24h' ? 'HH:mm' : 'p',
+										)}
 									</p>
 								)}
 							</div>

--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { fbt } from 'fbtee';
-import { Coins, Globe, LayoutGrid, Moon, Ruler } from 'lucide-react';
+import { Clock, Coins, Globe, LayoutGrid, Moon, Ruler } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -18,6 +18,7 @@ import { Currency, useCurrency } from '@/hooks/use-currency';
 import { useDevMode } from '@/hooks/use-dev-mode';
 import { useShowComparisonCharts } from '@/hooks/use-show-comparison-charts';
 import { useShowFeeding } from '@/hooks/use-show-feeding';
+import { useTimeFormat } from '@/hooks/use-time-format';
 import { useUnitSystem } from '@/hooks/use-unit-system';
 import { Locale } from '@/i18n';
 import { SettingsHeader } from '../components/settings-header';
@@ -26,6 +27,7 @@ export default function AppearanceSettingsPage() {
 	const { setTheme, theme } = useTheme();
 	const { locale, setLocale } = useLanguage();
 	const [unitSystem, setUnitSystem] = useUnitSystem();
+	const [timeFormat, setTimeFormat] = useTimeFormat();
 	const [currency, setCurrency] = useCurrency();
 	const [devMode, setDevMode] = useDevMode();
 	const [showComparisonCharts, setShowComparisonCharts] =
@@ -66,6 +68,35 @@ export default function AppearanceSettingsPage() {
 								<SelectContent>
 									<SelectItem value="de-DE">German</SelectItem>
 									<SelectItem value="en-US">English</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-2">
+							<div className="flex items-center gap-2">
+								<Clock className="h-4 w-4" />
+								<p className="text-sm font-medium">
+									<fbt desc="Label for time format setting">Time Format</fbt>
+								</p>
+							</div>
+							<Select
+								onValueChange={(v) => {
+									if (v) {
+										setTimeFormat(v as '12h' | '24h');
+									}
+								}}
+								value={timeFormat}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="12h">
+										<fbt desc="12-hour time format option">12-hour</fbt>
+									</SelectItem>
+									<SelectItem value="24h">
+										<fbt desc="24-hour time format option">24-hour</fbt>
+									</SelectItem>
 								</SelectContent>
 							</Select>
 						</div>

--- a/src/app/statistics/components/heat-map.test.tsx
+++ b/src/app/statistics/components/heat-map.test.tsx
@@ -1,10 +1,17 @@
 import { fireEvent, render, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { createStore } from 'tinybase';
+import { Provider } from 'tinybase/ui-react';
+import { describe, expect, it, vi } from 'vitest';
+import { useLanguage } from '@/contexts/i18n-context';
 import {
 	createFeedingSession,
 	createFeedingSessions,
 } from '@/test-utils/factories/feeding-session';
 import HeatMap from './heat-map';
+
+vi.mock('@/contexts/i18n-context', () => ({
+	useLanguage: vi.fn(),
+}));
 
 const mockSessions = createFeedingSessions([
 	{ breast: 'left', durationInSeconds: 540, startTime: '2024-01-01T00:00:00Z' },
@@ -17,8 +24,21 @@ const mockSessions = createFeedingSessions([
 ]);
 
 describe('HeatMap', () => {
+	const renderHeatMap = (sessions = mockSessions, locale = 'de-DE') => {
+		const store = createStore();
+		vi.mocked(useLanguage).mockReturnValue({
+			locale,
+			setLocale: vi.fn(),
+		});
+		return render(
+			<Provider store={store}>
+				<HeatMap sessions={sessions} />
+			</Provider>,
+		);
+	};
+
 	it('renders null when no sessions are provided', () => {
-		const { container } = render(<HeatMap sessions={[]} />);
+		const { container } = renderHeatMap([]);
 		expect(container.firstChild).toBeNull();
 	});
 
@@ -30,9 +50,7 @@ describe('HeatMap', () => {
 				startTime: '2024-01-01T00:00:00Z',
 			}),
 		];
-		const { container } = render(
-			<HeatMap sessions={singleZeroDurationSession} />,
-		);
+		const { container } = renderHeatMap(singleZeroDurationSession);
 		const heatMapCard = container.firstChild as HTMLElement;
 		expect(heatMapCard).not.toBeNull();
 		expect(
@@ -41,7 +59,7 @@ describe('HeatMap', () => {
 	});
 
 	it('renders the heat map with correct number of interval divs', () => {
-		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const { container } = renderHeatMap();
 		const heatMapCard = container.firstChild as HTMLElement;
 		expect(
 			within(heatMapCard).getAllByText('Daily Feeding Distribution')[0],
@@ -57,7 +75,7 @@ describe('HeatMap', () => {
 	});
 
 	it('renders time markers and legend', () => {
-		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const { container } = renderHeatMap();
 		const heatMapCard = container.firstChild as HTMLElement;
 
 		expect(within(heatMapCard).getAllByText('00:00')[0]).toBeInTheDocument();
@@ -83,8 +101,22 @@ describe('HeatMap', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders time markers in 12h format for en-US', () => {
+		const { container } = renderHeatMap(mockSessions, 'en-US');
+		const heatMapCard = container.firstChild as HTMLElement;
+
+		expect(within(heatMapCard).getAllByText('12 AM')[0]).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('3 AM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('6 AM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('9 AM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('12 PM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('3 PM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('6 PM')).toBeInTheDocument();
+		expect(within(heatMapCard).getByText('9 PM')).toBeInTheDocument();
+	});
+
 	it('applies different background colors based on intensity', () => {
-		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const { container } = renderHeatMap();
 		const heatMapCard = container.firstChild as HTMLElement;
 
 		const heatMapContainer = heatMapCard.querySelector('.cursor-crosshair');
@@ -98,7 +130,7 @@ describe('HeatMap', () => {
 	});
 
 	it('shows magnifying lens on pointer interaction', () => {
-		const { container } = render(<HeatMap sessions={mockSessions} />);
+		const { container } = renderHeatMap();
 		const heatMapCard = container.firstChild as HTMLElement;
 
 		const heatMapContainer = heatMapCard.querySelector('.cursor-crosshair');

--- a/src/app/statistics/components/heat-map.test.tsx
+++ b/src/app/statistics/components/heat-map.test.tsx
@@ -3,6 +3,7 @@ import { createStore } from 'tinybase';
 import { Provider } from 'tinybase/ui-react';
 import { describe, expect, it, vi } from 'vitest';
 import { useLanguage } from '@/contexts/i18n-context';
+import type { Locale } from '@/i18n';
 import {
 	createFeedingSession,
 	createFeedingSessions,
@@ -24,7 +25,10 @@ const mockSessions = createFeedingSessions([
 ]);
 
 describe('HeatMap', () => {
-	const renderHeatMap = (sessions = mockSessions, locale = 'de-DE') => {
+	const renderHeatMap = (
+		sessions = mockSessions,
+		locale: Locale = 'de-DE',
+	) => {
 		const store = createStore();
 		vi.mocked(useLanguage).mockReturnValue({
 			locale,

--- a/src/app/statistics/components/heat-map.test.tsx
+++ b/src/app/statistics/components/heat-map.test.tsx
@@ -1,9 +1,9 @@
+import type { Locale } from '@/i18n';
 import { fireEvent, render, within } from '@testing-library/react';
 import { createStore } from 'tinybase';
 import { Provider } from 'tinybase/ui-react';
 import { describe, expect, it, vi } from 'vitest';
 import { useLanguage } from '@/contexts/i18n-context';
-import type { Locale } from '@/i18n';
 import {
 	createFeedingSession,
 	createFeedingSessions,
@@ -25,10 +25,7 @@ const mockSessions = createFeedingSessions([
 ]);
 
 describe('HeatMap', () => {
-	const renderHeatMap = (
-		sessions = mockSessions,
-		locale: Locale = 'de-DE',
-	) => {
+	const renderHeatMap = (sessions = mockSessions, locale: Locale = 'de-DE') => {
 		const store = createStore();
 		vi.mocked(useLanguage).mockReturnValue({
 			locale,

--- a/src/app/statistics/components/heat-map.tsx
+++ b/src/app/statistics/components/heat-map.tsx
@@ -1,4 +1,5 @@
 import type { FeedingSession } from '@/types/feeding';
+import { format, parse } from 'date-fns';
 import { fbt } from 'fbtee';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
@@ -8,6 +9,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/components/ui/card';
+import { useTimeFormat } from '@/hooks/use-time-format';
 import { HeatMapTooltip } from './heat-map-tooltip';
 
 interface HeatMapProps {
@@ -75,6 +77,7 @@ function calculateDisplayIntervals(distribution: number[]) {
 
 export default function HeatMap({ className, sessions = [] }: HeatMapProps) {
 	const [activeIndex, setActiveIndex] = useState<number | null>(null);
+	const [timeFormat] = useTimeFormat();
 	const [pointerX, setPointerX] = useState<number | null>(null);
 	const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -89,10 +92,19 @@ export default function HeatMap({ className, sessions = [] }: HeatMapProps) {
 	const maxCount = useMemo(() => Math.max(...distribution), [distribution]);
 
 	// Create display intervals
-	const displayIntervals = useMemo(
-		() => calculateDisplayIntervals(distribution),
-		[distribution],
-	);
+	const displayIntervals = useMemo(() => {
+		const intervals = calculateDisplayIntervals(distribution);
+		if (timeFormat === '12h') {
+			return intervals.map((interval) => {
+				const date = parse(interval.time, 'HH:mm', new Date());
+				return {
+					...interval,
+					time: format(date, 'p'),
+				};
+			});
+		}
+		return intervals;
+	}, [distribution, timeFormat]);
 
 	const handlePointerMove = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
@@ -225,14 +237,18 @@ export default function HeatMap({ className, sessions = [] }: HeatMapProps) {
 									<div
 										className={`absolute bottom-3 -translate-x-1/2 transform text-[10px] text-muted-foreground ${hour % 6 === 0 ? '' : 'hidden sm:block'}`}
 									>
-										{hour.toString().padStart(2, '0')}:00
+										{timeFormat === '24h'
+											? `${hour.toString().padStart(2, '0')}:00`
+											: format(new Date().setHours(hour, 0, 0, 0), 'h a')}
 									</div>
 								</div>
 							))}
 							<div className="absolute bottom-0 right-0">
 								<div className="h-2 w-px bg-zinc-400 dark:bg-zinc-500"></div>
 								<div className="absolute bottom-3 right-0 translate-x-1/2 transform text-[10px] text-muted-foreground">
-									24:00
+									{timeFormat === '24h'
+										? '24:00'
+										: format(new Date().setHours(0, 0, 0, 0), 'h a')}
 								</div>
 							</div>
 						</div>

--- a/src/hooks/use-time-format.test.tsx
+++ b/src/hooks/use-time-format.test.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'tinybase';
+import { Provider } from 'tinybase/ui-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLanguage } from '@/contexts/i18n-context';
+import { STORE_VALUE_TIME_FORMAT } from '@/lib/tinybase-sync/constants';
+import { useTimeFormat } from './use-time-format';
+
+vi.mock('@/contexts/i18n-context', () => ({
+	useLanguage: vi.fn(),
+}));
+
+describe('useTimeFormat', () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+		vi.mocked(useLanguage).mockReturnValue({
+			locale: 'en-US',
+			setLocale: vi.fn(),
+		});
+	});
+
+	const wrapper = ({ children }: { children: React.ReactNode }) => (
+		<Provider store={store}>{children}</Provider>
+	);
+
+	it('defaults to 12h for en-US locale', () => {
+		const { result } = renderHook(() => useTimeFormat(), { wrapper });
+		expect(result.current[0]).toBe('12h');
+	});
+
+	it('defaults to 24h for other locales', () => {
+		vi.mocked(useLanguage).mockReturnValue({
+			locale: 'de-DE',
+			setLocale: vi.fn(),
+		});
+		const { result } = renderHook(() => useTimeFormat(), { wrapper });
+		expect(result.current[0]).toBe('24h');
+	});
+
+	it('returns value from store if set', () => {
+		store.setValue(STORE_VALUE_TIME_FORMAT, '24h');
+		const { result } = renderHook(() => useTimeFormat(), { wrapper });
+		expect(result.current[0]).toBe('24h');
+	});
+
+	it('updates store when setter is called', () => {
+		const { result } = renderHook(() => useTimeFormat(), { wrapper });
+		act(() => {
+			result.current[1]('24h');
+		});
+		expect(store.getValue(STORE_VALUE_TIME_FORMAT)).toBe('24h');
+		expect(result.current[0]).toBe('24h');
+	});
+});

--- a/src/hooks/use-time-format.ts
+++ b/src/hooks/use-time-format.ts
@@ -16,8 +16,7 @@ export function useTimeFormat() {
 		[],
 	);
 
-	const defaultTimeFormat: TimeFormat =
-		locale === 'en-US' ? '12h' : '24h';
+	const defaultTimeFormat: TimeFormat = locale === 'en-US' ? '12h' : '24h';
 
 	return [timeFormat ?? defaultTimeFormat, setTimeFormat] as const;
 }

--- a/src/hooks/use-time-format.ts
+++ b/src/hooks/use-time-format.ts
@@ -1,0 +1,23 @@
+import { useSetValueCallback, useValue } from 'tinybase/ui-react';
+import { useLanguage } from '@/contexts/i18n-context';
+import { STORE_VALUE_TIME_FORMAT } from '@/lib/tinybase-sync/constants';
+
+export type TimeFormat = '12h' | '24h';
+
+export function useTimeFormat() {
+	const { locale } = useLanguage();
+	const timeFormat = useValue(STORE_VALUE_TIME_FORMAT) as
+		| TimeFormat
+		| undefined;
+
+	const setTimeFormat = useSetValueCallback(
+		STORE_VALUE_TIME_FORMAT,
+		(newTimeFormat: TimeFormat) => newTimeFormat,
+		[],
+	);
+
+	const defaultTimeFormat: TimeFormat =
+		locale === 'en-US' ? '12h' : '24h';
+
+	return [timeFormat ?? defaultTimeFormat, setTimeFormat] as const;
+}

--- a/src/lib/tinybase-sync/constants.ts
+++ b/src/lib/tinybase-sync/constants.ts
@@ -8,6 +8,7 @@ export const STORE_VALUE_FEEDING_IN_PROGRESS = 'feedingInProgress';
 export const STORE_VALUE_PROFILE = 'profile';
 export const STORE_VALUE_SELECTED_PROFILE_ID = 'selectedProfileId';
 export const STORE_VALUE_SHOW_FEEDING = 'showFeeding';
+export const STORE_VALUE_TIME_FORMAT = 'timeFormat';
 export const STORE_VALUE_UNIT_SYSTEM = 'unitSystem';
 
 export const TABLE_IDS = {


### PR DESCRIPTION
Implemented a way for users to manually set their preferred time format (12h/24h) in the Appearance Settings. This setting persists in the TinyBase store and overrides the default locale-based formatting across the application, including history entries, active trackers, and statistical charts.

---
*PR created automatically by Jules for task [2975919145052611268](https://jules.google.com/task/2975919145052611268) started by @clentfort*