### PR TITLE
Improve test coverage for diaper row normalization migration

### DIFF
--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -237,4 +237,28 @@ describe('runMigrations', () => {
 		expect(result.skippedMigrationIds).toContain(RENAME_MIGRATION_ID);
 		expect(result.appliedMigrationIds).not.toContain(RENAME_MIGRATION_ID);
 	});
+
+	it('improves coverage of diaper row normalization by handling already-normalized and invalid rows', () => {
+		const store = createStore();
+		const normalizedRow = {
+			containsStool: false,
+			containsUrine: true,
+			timestamp: '2026-03-01T08:00:00.000Z',
+		};
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd1', normalizedRow);
+
+		// Invalid row: Missing required 'timestamp' field
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd2', {
+			containsStool: false,
+			containsUrine: true,
+		});
+
+		const result = runMigrations(store);
+
+		expect(result.appliedMigrationIds).toContain(
+			NORMALIZE_DIAPER_ROWS_MIGRATION_ID,
+		);
+		expect(store.getRow(TABLE_IDS.DIAPER_CHANGES, 'd1')).toEqual(normalizedRow);
+		expect(store.hasRow(TABLE_IDS.DIAPER_CHANGES, 'd2')).toBe(false);
+	});
 });


### PR DESCRIPTION
I identified that `src/migrations/2026-03-07-normalize-diaper-store-rows.ts` was one of the files with the lowest reachable test coverage (85.71% Statements). I added a single test case to `src/migrations/index.test.ts` that provides both an already-normalized row and an invalid row to the TinyBase store before running migrations. This exercises the previously uncovered `continue` and deletion branches in the migration logic, bringing the file's coverage to 100%.

---
*PR created automatically by Jules for task [3652115271481323642](https://jules.google.com/task/3652115271481323642) started by @clentfort*