### PR TITLE
Improve test coverage for partykit-host.ts

### DIFF
--- a/src/lib/partykit-host.test.ts
+++ b/src/lib/partykit-host.test.ts
@@ -49,7 +49,9 @@ describe('resolvePartykitHost', () => {
 
 	it('covers additional edge cases and environment helper', () => {
 		expect(
-			getPartykitHostFromEnv({ NEXT_PUBLIC_PARTYKIT_HOST: 'env.example.com' }),
+			getPartykitHostFromEnv({
+				NEXT_PUBLIC_PARTYKIT_HOST: 'env.example.com',
+			} as unknown as NodeJS.ProcessEnv),
 		).toBe('env.example.com');
 
 		expect(resolvePartykitHost({ vercelEnv: 'preview' })).toBe(

--- a/src/lib/partykit-host.test.ts
+++ b/src/lib/partykit-host.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolvePartykitHost } from './partykit-host';
+import { getPartykitHostFromEnv, resolvePartykitHost } from './partykit-host';
 
 describe('resolvePartykitHost', () => {
 	it('returns production host by default', () => {
@@ -45,5 +45,19 @@ describe('resolvePartykitHost', () => {
 				explicitHost: 'https://custom.adameter.example/',
 			}),
 		).toBe('custom.adameter.example');
+	});
+
+	it('covers additional edge cases and environment helper', () => {
+		expect(
+			getPartykitHostFromEnv({ NEXT_PUBLIC_PARTYKIT_HOST: 'env.example.com' }),
+		).toBe('env.example.com');
+
+		expect(resolvePartykitHost({ vercelEnv: 'preview' })).toBe(
+			'adameter-party.clentfort.partykit.dev',
+		);
+
+		expect(
+			resolvePartykitHost({ vercelEnv: 'preview', vercelGitCommitRef: '!!!' }),
+		).toBe('branch-preview.adameter-party.clentfort.partykit.dev');
 	});
 });


### PR DESCRIPTION
I have improved the test coverage for `src/lib/partykit-host.ts` by adding a single test case that exercises previously uncovered functions and branches. 

Specifically, I added:
- A test for `getPartykitHostFromEnv` to verify it correctly resolves hosts from environment objects.
- Tests for `resolvePartykitHost` in a Vercel preview environment to cover fallback branches in `getPreviewName` and `normalizePreviewId` (e.g., when `vercelGitCommitRef` is missing or contains only special characters).

The statement coverage for `src/lib/partykit-host.ts` is now 100%. All tests passed successfully.

---
*PR created automatically by Jules for task [17311269305249134977](https://jules.google.com/task/17311269305249134977) started by @clentfort*