### PR TITLE
Improve test coverage for useLastUsedDiaperProduct hook

### DIFF
--- a/src/app/diaper/hooks/use-last-used-diaper-product.test.ts
+++ b/src/app/diaper/hooks/use-last-used-diaper-product.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useLatestDiaperChangeRecord } from '@/hooks/use-diaper-changes';
+import { useLastUsedDiaperProduct } from './use-last-used-diaper-product';
+
+vi.mock('@/hooks/use-diaper-changes', () => ({
+	useLatestDiaperChangeRecord: vi.fn(),
+}));
+
+describe('useLastUsedDiaperProduct', () => {
+	it('returns undefined when there is no latest diaper change', () => {
+		vi.mocked(useLatestDiaperChangeRecord).mockReturnValue(undefined);
+
+		const { result } = renderHook(() => useLastUsedDiaperProduct());
+
+		expect(result.current).toBeUndefined();
+	});
+
+	it('returns diaperProductId from the latest diaper change', () => {
+		vi.mocked(useLatestDiaperChangeRecord).mockReturnValue({
+			diaperProductId: 'test-product-id',
+			id: 'test-id',
+			timestamp: '2024-01-01T10:00:00Z',
+		} as any);
+
+		const { result } = renderHook(() => useLastUsedDiaperProduct());
+
+		expect(result.current).toBe('test-product-id');
+	});
+
+	it('returns undefined if the latest diaper change has no diaperProductId', () => {
+		vi.mocked(useLatestDiaperChangeRecord).mockReturnValue({
+			id: 'test-id',
+			timestamp: '2024-01-01T10:00:00Z',
+		} as any);
+
+		const { result } = renderHook(() => useLastUsedDiaperProduct());
+
+		expect(result.current).toBeUndefined();
+	});
+});

--- a/src/app/diaper/hooks/use-last-used-diaper-product.test.ts
+++ b/src/app/diaper/hooks/use-last-used-diaper-product.test.ts
@@ -1,3 +1,4 @@
+import type { DiaperChange } from '@/types/diaper';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useLatestDiaperChangeRecord } from '@/hooks/use-diaper-changes';
@@ -21,7 +22,7 @@ describe('useLastUsedDiaperProduct', () => {
 			diaperProductId: 'test-product-id',
 			id: 'test-id',
 			timestamp: '2024-01-01T10:00:00Z',
-		} as any);
+		} as unknown as DiaperChange);
 
 		const { result } = renderHook(() => useLastUsedDiaperProduct());
 
@@ -32,7 +33,7 @@ describe('useLastUsedDiaperProduct', () => {
 		vi.mocked(useLatestDiaperChangeRecord).mockReturnValue({
 			id: 'test-id',
 			timestamp: '2024-01-01T10:00:00Z',
-		} as any);
+		} as unknown as DiaperChange);
 
 		const { result } = renderHook(() => useLastUsedDiaperProduct());
 


### PR DESCRIPTION
I have improved the test coverage by adding a new test file for the `useLastUsedDiaperProduct` hook, which previously had 0% coverage. The new test suite covers all logical branches of the hook and achieves 100% coverage. I have also verified that all existing 424 unit tests pass.

---
*PR created automatically by Jules for task [9227516565846747944](https://jules.google.com/task/9227516565846747944) started by @clentfort*