### PR TITLE
Improve test coverage for diaper-brands.ts

### DIFF
--- a/src/app/diaper/utils/diaper-brands.test.ts
+++ b/src/app/diaper/utils/diaper-brands.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_DIAPER_BRAND,
+	DIAPER_BRAND_LABELS,
+	DIAPER_BRANDS,
+} from './diaper-brands';
+
+describe('diaper-brands', () => {
+	it('should have a list of diaper brands', () => {
+		expect(DIAPER_BRANDS).toBeDefined();
+		expect(Array.isArray(DIAPER_BRANDS)).toBe(true);
+		expect(DIAPER_BRANDS.length).toBeGreaterThan(0);
+	});
+
+	it('should have correct brand labels mapping', () => {
+		expect(DIAPER_BRAND_LABELS).toBeDefined();
+		DIAPER_BRANDS.forEach((brand) => {
+			expect(DIAPER_BRAND_LABELS[brand.value]).toBe(brand.label);
+		});
+	});
+
+	it('should have a default diaper brand', () => {
+		expect(DEFAULT_DIAPER_BRAND).toBeDefined();
+		expect(typeof DEFAULT_DIAPER_BRAND).toBe('string');
+		expect(DIAPER_BRANDS.some((b) => b.value === DEFAULT_DIAPER_BRAND)).toBe(
+			true,
+		);
+	});
+});


### PR DESCRIPTION
Added unit tests for `src/app/diaper/utils/diaper-brands.ts` to improve coverage from 0% to 100% (Statements). The tests verify the `DIAPER_BRANDS`, `DIAPER_BRAND_LABELS`, and `DEFAULT_DIAPER_BRAND` constants.

---
*PR created automatically by Jules for task [12855375154264939990](https://jules.google.com/task/12855375154264939990) started by @clentfort*