### PR TITLE
Improve test coverage for TotalDurationStats component

### DIFF
--- a/src/app/statistics/components/total-duration-stats.test.tsx
+++ b/src/app/statistics/components/total-duration-stats.test.tsx
@@ -35,4 +35,20 @@ describe('TotalDurationStats', () => {
 		render(<TotalDurationStats sessions={zeroDurationSessions} />);
 		expect(screen.getByText('0 min')).toBeInTheDocument();
 	});
+
+	it('displays comparison value when comparisonSessions are provided', () => {
+		const comparisonSessions = createFeedingSessions([
+			{ breast: 'left', durationInSeconds: 300 },
+		]);
+		render(
+			<TotalDurationStats
+				comparisonSessions={comparisonSessions}
+				sessions={mockSessions}
+			/>,
+		);
+		// mockSessions total is 1800s (30 min)
+		// comparisonSessions total is 300s (5 min)
+		// Increase is 1500s. 1500/300 * 100 = 500%
+		expect(screen.getByText('↑500%')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
Identified `TotalDurationStats` as a component with lower test coverage (88.88% statements). Added a test case in `src/app/statistics/components/total-duration-stats.test.tsx` that provides the `comparisonSessions` prop, which exercises the previously uncovered `useMemo` for calculating comparison data and the conditional rendering of the `ComparisonValue` component. Verified that statement coverage for the file now reaches 100%.

---
*PR created automatically by Jules for task [8930642940582775626](https://jules.google.com/task/8930642940582775626) started by @clentfort*