### PR TITLE
Improve test coverage for i18n-context

### DIFF
--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import * as i18n from '@/i18n';
+import { I18nContext, I18nProvider, useLanguage } from './i18n-context';
+
+vi.mock('@/i18n', async (importOriginal) => {
+	const actual = (await importOriginal()) as typeof i18n;
+	return {
+		...actual,
+		getPreferredLocale: vi.fn(() => 'en-US'),
+		setLocale: vi.fn(() => Promise.resolve()),
+	};
+});
+
+describe('I18nContext', () => {
+	it('should provide default locale', () => {
+		const { result } = renderHook(() => useLanguage(), {
+			wrapper: I18nProvider,
+		});
+
+		expect(result.current.locale).toBe('en-US');
+	});
+
+	it('should update locale when setLocale is called', async () => {
+		const { result } = renderHook(() => useLanguage(), {
+			wrapper: I18nProvider,
+		});
+
+		await act(async () => {
+			await result.current.setLocale('de-DE');
+		});
+
+		expect(result.current.locale).toBe('de-DE');
+		expect(i18n.setLocale).toHaveBeenCalledWith('de-DE');
+	});
+
+	it('should call setLocale with preferred locale on mount', () => {
+		vi.mocked(i18n.getPreferredLocale).mockReturnValue('de-DE');
+
+		renderHook(() => useLanguage(), {
+			wrapper: I18nProvider,
+		});
+
+		expect(i18n.setLocale).toHaveBeenCalledWith('de-DE');
+	});
+
+	it('should throw error when useLanguage is used outside I18nProvider', () => {
+		// To reach line 54, we need useContext(I18nContext) to return null.
+		// We can achieve this by providing null as value in the Provider.
+
+		const { result } = renderHook(() => {
+			try {
+				return useLanguage();
+			} catch (e) {
+				return e;
+			}
+		}, {
+			// @ts-expect-error - testing error branch
+			wrapper: ({ children }) => <I18nContext.Provider value={null}>{children}</I18nContext.Provider>
+		});
+
+		expect(result.current).toBeInstanceOf(Error);
+		expect((result.current as Error).message).toBe('useLanguage must be used within a LanguageProvider');
+	});
+});

--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import * as i18n from '@/i18n';
+import { getPreferredLocale, setLocale } from '@/i18n';
 import { I18nContext, I18nProvider, useLanguage } from './i18n-context';
 
 vi.mock('@/i18n', async (importOriginal) => {
-	const actual = (await importOriginal()) as typeof i18n;
+	const actual = (await importOriginal()) as typeof import('@/i18n');
 	return {
 		...actual,
 		getPreferredLocale: vi.fn(() => 'en-US'),
@@ -31,35 +31,42 @@ describe('I18nContext', () => {
 		});
 
 		expect(result.current.locale).toBe('de-DE');
-		expect(i18n.setLocale).toHaveBeenCalledWith('de-DE');
+		expect(setLocale).toHaveBeenCalledWith('de-DE');
 	});
 
 	it('should call setLocale with preferred locale on mount', () => {
-		vi.mocked(i18n.getPreferredLocale).mockReturnValue('de-DE');
+		vi.mocked(getPreferredLocale).mockReturnValue('de-DE');
 
 		renderHook(() => useLanguage(), {
 			wrapper: I18nProvider,
 		});
 
-		expect(i18n.setLocale).toHaveBeenCalledWith('de-DE');
+		expect(setLocale).toHaveBeenCalledWith('de-DE');
 	});
 
 	it('should throw error when useLanguage is used outside I18nProvider', () => {
 		// To reach line 54, we need useContext(I18nContext) to return null.
 		// We can achieve this by providing null as value in the Provider.
 
-		const { result } = renderHook(() => {
-			try {
-				return useLanguage();
-			} catch (e) {
-				return e;
-			}
-		}, {
-			// @ts-expect-error - testing error branch
-			wrapper: ({ children }) => <I18nContext.Provider value={null}>{children}</I18nContext.Provider>
-		});
+		const { result } = renderHook(
+			() => {
+				try {
+					return useLanguage();
+				} catch (error) {
+					return error;
+				}
+			},
+			{
+				// @ts-expect-error - testing error branch
+				wrapper: ({ children }) => (
+					<I18nContext.Provider value={null}>{children}</I18nContext.Provider>
+				),
+			},
+		);
 
 		expect(result.current).toBeInstanceOf(Error);
-		expect((result.current as Error).message).toBe('useLanguage must be used within a LanguageProvider');
+		expect((result.current as Error).message).toBe(
+			'useLanguage must be used within a LanguageProvider',
+		);
 	});
 });

--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { getPreferredLocale, setLocale } from '@/i18n';
+import { getPreferredLocale, Locale, setLocale } from '@/i18n';
 import { I18nContext, I18nProvider, useLanguage } from './i18n-context';
 
 vi.mock('@/i18n', async (importOriginal) => {
@@ -11,6 +11,11 @@ vi.mock('@/i18n', async (importOriginal) => {
 		setLocale: vi.fn(() => Promise.resolve()),
 	};
 });
+
+type I18nContextType = {
+	locale: Locale;
+	setLocale: (lang: Locale) => Promise<void>;
+};
 
 describe('I18nContext', () => {
 	it('should provide default locale', () => {
@@ -58,7 +63,9 @@ describe('I18nContext', () => {
 			},
 			{
 				wrapper: ({ children }) => (
-					<I18nContext.Provider value={null as any}>{children}</I18nContext.Provider>
+					<I18nContext.Provider value={null as unknown as I18nContextType}>
+						{children}
+					</I18nContext.Provider>
 				),
 			},
 		);

--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -57,9 +57,8 @@ describe('I18nContext', () => {
 				}
 			},
 			{
-				// @ts-expect-error - testing error branch
 				wrapper: ({ children }) => (
-					<I18nContext.Provider value={null}>{children}</I18nContext.Provider>
+					<I18nContext.Provider value={null as any}>{children}</I18nContext.Provider>
 				),
 			},
 		);


### PR DESCRIPTION
I have improved the test coverage of the codebase by targeting the `src/contexts/i18n-context.tsx` file, which was one of the functional files with the lowest coverage.

I created a new test file `src/contexts/i18n-context.test.tsx` that includes test cases for:
- Initializing `I18nProvider` with the default locale.
- Updating the locale using `setLocale`.
- Verifying that `setLocale` is called with the preferred locale on mount.
- Ensuring `useLanguage` throws an error when used outside of an `I18nProvider`.

These tests cover all branches and lines in `src/contexts/i18n-context.tsx`, bringing its coverage to 100%. I also verified that all existing unit tests in the repository pass.

---
*PR created automatically by Jules for task [281724075025836575](https://jules.google.com/task/281724075025836575) started by @clentfort*