### PR TITLE
Improve test coverage for use-events and i18n-context

### DIFF
--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -1,0 +1,61 @@
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { I18nContext, I18nProvider, useLanguage } from './i18n-context';
+
+describe('I18nProvider', () => {
+	it('should provide the default locale and update it when setLocale is called', async () => {
+		const TestComponent = () => {
+			const { locale, setLocale } = useLanguage();
+			return (
+				<div>
+					<span data-testid="locale">{locale}</span>
+					<button onClick={() => setLocale('de-DE')}>Change Locale</button>
+				</div>
+			);
+		};
+
+		render(
+			<I18nProvider>
+				<TestComponent />
+			</I18nProvider>,
+		);
+
+		// Initial locale should be en-US (default)
+		expect(screen.getByTestId('locale')).toHaveTextContent('en-US');
+
+		// Click the button to change the locale
+		await act(async () => {
+			screen.getByText('Change Locale').click();
+		});
+
+		// Locale should update to de-DE
+		expect(await screen.findByTestId('locale')).toHaveTextContent('de-DE');
+	});
+
+	it('should throw an error when context is missing (useLanguage error branch)', () => {
+		const TestComponent = () => {
+			useLanguage();
+			return null;
+		};
+
+		// Prevent console.error from cluttering the output
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		// To trigger the !context branch, we need to wrap it in a Provider that provides null
+		// or just call it outside of any provider.
+		// Actually, useContext(I18nContext) will return the default value if no provider is present.
+		// The default value for I18nContext is { locale: DEFAULT_LOCALE, setLocale: async () => {} }.
+		// So it's never null by default.
+
+		// To test the error branch, we can explicitly provide null to the context.
+		expect(() => render(
+			<I18nContext.Provider value={null as any}>
+				<TestComponent />
+			</I18nContext.Provider>
+		)).toThrow(
+			'useLanguage must be used within a LanguageProvider',
+		);
+
+		consoleSpy.mockRestore();
+	});
+});

--- a/src/contexts/i18n-context.test.tsx
+++ b/src/contexts/i18n-context.test.tsx
@@ -1,19 +1,25 @@
+import type { I18nContextType } from './i18n-context';
 import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { I18nContext, I18nProvider, useLanguage } from './i18n-context';
 
+const TestComponent = () => {
+	const { locale, setLocale } = useLanguage();
+	return (
+		<div>
+			<span data-testid="locale">{locale}</span>
+			<button onClick={() => void setLocale('de-DE')}>Change Locale</button>
+		</div>
+	);
+};
+
+const ErrorTestComponent = () => {
+	useLanguage();
+	return null;
+};
+
 describe('I18nProvider', () => {
 	it('should provide the default locale and update it when setLocale is called', async () => {
-		const TestComponent = () => {
-			const { locale, setLocale } = useLanguage();
-			return (
-				<div>
-					<span data-testid="locale">{locale}</span>
-					<button onClick={() => setLocale('de-DE')}>Change Locale</button>
-				</div>
-			);
-		};
-
 		render(
 			<I18nProvider>
 				<TestComponent />
@@ -33,11 +39,6 @@ describe('I18nProvider', () => {
 	});
 
 	it('should throw an error when context is missing (useLanguage error branch)', () => {
-		const TestComponent = () => {
-			useLanguage();
-			return null;
-		};
-
 		// Prevent console.error from cluttering the output
 		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -48,13 +49,13 @@ describe('I18nProvider', () => {
 		// So it's never null by default.
 
 		// To test the error branch, we can explicitly provide null to the context.
-		expect(() => render(
-			<I18nContext.Provider value={null as any}>
-				<TestComponent />
-			</I18nContext.Provider>
-		)).toThrow(
-			'useLanguage must be used within a LanguageProvider',
-		);
+		expect(() =>
+			render(
+				<I18nContext.Provider value={null as unknown as I18nContextType}>
+					<ErrorTestComponent />
+				</I18nContext.Provider>,
+			),
+		).toThrow('useLanguage must be used within a LanguageProvider');
 
 		consoleSpy.mockRestore();
 	});

--- a/src/contexts/i18n-context.tsx
+++ b/src/contexts/i18n-context.tsx
@@ -15,7 +15,7 @@ import {
 	setLocale as setAppLocale,
 } from '@/i18n';
 
-type I18nContextType = {
+export type I18nContextType = {
 	locale: Locale;
 	setLocale: (lang: Locale) => Promise<void>;
 };

--- a/src/hooks/use-events.test.tsx
+++ b/src/hooks/use-events.test.tsx
@@ -136,31 +136,4 @@ describe('useEvents', () => {
 			expect(result.current[0].id).toBe('e1');
 		});
 	});
-
-	describe('toEvent error handling', () => {
-		it('should handle invalid event data and log a warning', () => {
-			const store = createTestStore();
-			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-			// Missing required 'type' field
-			store.setRow(TABLE_IDS.EVENTS, 'invalid-1', {
-				startDate: '2024-01-01T10:00:00Z',
-				title: 'Invalid Event',
-			});
-
-			const { result } = renderHook(() => useEvent('invalid-1'), {
-				wrapper: ({ children }) => (
-					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
-				),
-			});
-
-			expect(result.current).toBeUndefined();
-			expect(consoleSpy).toHaveBeenCalledWith(
-				expect.stringContaining('Invalid event data for id invalid-1:'),
-				expect.any(Array),
-			);
-
-			consoleSpy.mockRestore();
-		});
-	});
 });

--- a/src/hooks/use-events.test.tsx
+++ b/src/hooks/use-events.test.tsx
@@ -136,4 +136,31 @@ describe('useEvents', () => {
 			expect(result.current[0].id).toBe('e1');
 		});
 	});
+
+	describe('toEvent error handling', () => {
+		it('should handle invalid event data and log a warning', () => {
+			const store = createTestStore();
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			// Missing required 'type' field
+			store.setRow(TABLE_IDS.EVENTS, 'invalid-1', {
+				startDate: '2024-01-01T10:00:00Z',
+				title: 'Invalid Event',
+			});
+
+			const { result } = renderHook(() => useEvent('invalid-1'), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+
+			expect(result.current).toBeUndefined();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid event data for id invalid-1:'),
+				expect.any(Array),
+			);
+
+			consoleSpy.mockRestore();
+		});
+	});
 });


### PR DESCRIPTION
I have improved the test coverage for the following files:
- `src/hooks/use-events.ts`: Reached 100% coverage by adding a test case that exercises the error handling branch in the `toEvent` mapper.
- `src/contexts/i18n-context.tsx`: Reached 100% coverage by creating a new test file `src/contexts/i18n-context.test.tsx` that covers the `I18nProvider` lifecycle and `useLanguage` hook error states.

All 425 unit tests passed successfully. Diagnostic files generated during the process have been removed.

---
*PR created automatically by Jules for task [9299222532808360256](https://jules.google.com/task/9299222532808360256) started by @clentfort*