### PR TITLE
Improve test coverage for use-events hook

### DIFF
--- a/src/hooks/use-events.test.tsx
+++ b/src/hooks/use-events.test.tsx
@@ -136,4 +136,28 @@ describe('useEvents', () => {
 			expect(result.current[0].id).toBe('e1');
 		});
 	});
+
+	describe('toEvent error handling', () => {
+		it('should warn and return null for invalid event data', () => {
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			const store = createTestStore();
+			// Missing required fields like title and startDate
+			store.setRow(TABLE_IDS.EVENTS, 'invalid-id', {
+				type: 'point',
+			});
+
+			const { result } = renderHook(() => useEvent('invalid-id'), {
+				wrapper: ({ children }) => (
+					<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+				),
+			});
+
+			expect(result.current).toBeUndefined();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid event data for id invalid-id:'),
+				expect.any(Array),
+			);
+			consoleSpy.mockRestore();
+		});
+	});
 });


### PR DESCRIPTION
Improved test coverage for the `useEvents` hook by adding a targeted test case for invalid record handling in the `toEvent` utility. Verified that `src/hooks/use-events.ts` now reaches 100% statement coverage and that all existing tests pass. Cleaned up all temporary files and ensured compliance with project coding standards.

---
*PR created automatically by Jules for task [6245395268947024467](https://jules.google.com/task/6245395268947024467) started by @clentfort*