### PR TITLE
Improve test coverage for useIdleCallback hook

### DIFF
--- a/src/hooks/use-idle-callback.test.tsx
+++ b/src/hooks/use-idle-callback.test.tsx
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { cancelIdleCallback, requestIdleCallback } from '@/lib/idle-callback';
+import { useIdleCallback } from './use-idle-callback';
+
+vi.mock('@/lib/idle-callback', () => ({
+	cancelIdleCallback: vi.fn(),
+	requestIdleCallback: vi.fn(() => {
+		// Simulate immediate execution for simple tests if needed,
+		// or just return a handle.
+		return 123;
+	}),
+}));
+
+describe('useIdleCallback', () => {
+	it('should schedule an idle callback on mount', () => {
+		const callback = vi.fn();
+		renderHook(() => useIdleCallback(callback));
+
+		expect(requestIdleCallback).toHaveBeenCalled();
+	});
+
+	it('should execute the callback when idle', () => {
+		let idleHandler: ((deadline: IdleDeadline) => void) | undefined;
+		vi.mocked(requestIdleCallback).mockImplementationOnce((cb) => {
+			idleHandler = cb;
+			return 123;
+		});
+
+		const callback = vi.fn();
+		renderHook(() => useIdleCallback(callback));
+
+		expect(idleHandler).toBeDefined();
+		idleHandler?.({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+		expect(callback).toHaveBeenCalled();
+	});
+
+	it('should cancel the idle callback on unmount', () => {
+		const handle = 123;
+		vi.mocked(requestIdleCallback).mockReturnValue(handle);
+
+		const { unmount } = renderHook(() => useIdleCallback(vi.fn()));
+
+		unmount();
+
+		expect(cancelIdleCallback).toHaveBeenCalledWith(handle);
+	});
+
+	it('should update the callback without rescheduling if dependencies do not change', () => {
+		vi.mocked(requestIdleCallback).mockClear();
+		const callback1 = vi.fn();
+		const callback2 = vi.fn();
+
+		let idleHandler: ((deadline: IdleDeadline) => void) | undefined;
+		vi.mocked(requestIdleCallback).mockImplementation((cb) => {
+			idleHandler = cb;
+			return 123;
+		});
+
+		const { rerender } = renderHook(({ cb }) => useIdleCallback(cb, []), {
+			initialProps: { cb: callback1 },
+		});
+
+		expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+		rerender({ cb: callback2 });
+
+		expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+		idleHandler?.({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+		expect(callback1).not.toHaveBeenCalled();
+		expect(callback2).toHaveBeenCalled();
+	});
+
+	it('should reschedule when dependencies change', () => {
+		vi.mocked(requestIdleCallback).mockClear();
+		vi.mocked(cancelIdleCallback).mockClear();
+
+		const callback = vi.fn();
+		const { rerender } = renderHook(
+			({ deps }) => useIdleCallback(callback, deps),
+			{ initialProps: { deps: [1] } },
+		);
+
+		expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+		rerender({ deps: [2] });
+
+		expect(cancelIdleCallback).toHaveBeenCalled();
+		expect(requestIdleCallback).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/hooks/use-idle-callback.test.tsx
+++ b/src/hooks/use-idle-callback.test.tsx
@@ -31,7 +31,10 @@ describe('useIdleCallback', () => {
 		renderHook(() => useIdleCallback(callback));
 
 		expect(idleHandler).toBeDefined();
-		idleHandler?.({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+		idleHandler?.({
+			didTimeout: false,
+			timeRemaining: () => 50,
+		} as IdleDeadline);
 		expect(callback).toHaveBeenCalled();
 	});
 
@@ -67,7 +70,10 @@ describe('useIdleCallback', () => {
 
 		expect(requestIdleCallback).toHaveBeenCalledTimes(1);
 
-		idleHandler?.({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+		idleHandler?.({
+			didTimeout: false,
+			timeRemaining: () => 50,
+		} as IdleDeadline);
 		expect(callback1).not.toHaveBeenCalled();
 		expect(callback2).toHaveBeenCalled();
 	});


### PR DESCRIPTION
Identified `src/hooks/use-idle-callback.ts` as a file with 0% coverage.
Added comprehensive unit tests in `src/hooks/use-idle-callback.test.tsx` covering:
- Scheduling on mount
- Execution when idle
- Cancellation on unmount
- Latest callback reference preservation (using `useRef`)
- Dependency-based rescheduling

All tests passed, and the hook now has 100% test coverage.
Cleaned up temporary files (`coverage_full.txt`, `source_strings.json`) and ensured linting passes.

---
*PR created automatically by Jules for task [12080258075812220865](https://jules.google.com/task/12080258075812220865) started by @clentfort*