### PR TITLE
Improve test coverage for TinybaseQueriesContext

### DIFF
--- a/src/contexts/tinybase-queries-context.test.tsx
+++ b/src/contexts/tinybase-queries-context.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { TinyBaseTestWrapper } from '@/test-utils/tinybase-test-wrapper';
+import {
+	QUERY_IDS,
+	TinybaseQueriesProvider,
+	useTinybaseQueries,
+} from './tinybase-queries-context';
+
+describe('TinybaseQueriesContext', () => {
+	it('should provide the queries infrastructure', () => {
+		// 1. Verify QUERY_IDS constants
+		expect(QUERY_IDS.GROWTH_HISTORY).toBe('growthHistory');
+
+		// 2. Verify behavior outside of provider
+		const { result: outsideResult } = renderHook(() => useTinybaseQueries());
+		expect(outsideResult.current).toBeUndefined();
+
+		// 3. Verify behavior inside of provider
+		const wrapper = ({ children }: { children: React.ReactNode }) => (
+			<TinyBaseTestWrapper>
+				<TinybaseQueriesProvider>{children}</TinybaseQueriesProvider>
+			</TinyBaseTestWrapper>
+		);
+
+		const { result: insideResult } = renderHook(() => useTinybaseQueries(), {
+			wrapper,
+		});
+
+		expect(insideResult.current).toBeDefined();
+		expect(insideResult.current).not.toBeNull();
+	});
+});


### PR DESCRIPTION
This PR adds unit test coverage for the TinybaseQueriesContext, which previously had 0% coverage. 

Key changes:
- Created `src/contexts/tinybase-queries-context.test.tsx`.
- Implemented a single test case that verifies the `QUERY_IDS` constants, as well as the behavior of the `useTinybaseQueries` hook both inside and outside of the `TinybaseQueriesProvider`.
- Achieved 100% coverage for the target file.
- Verified that all 463 tests in the suite pass.

---
*PR created automatically by Jules for task [10475551837913475119](https://jules.google.com/task/10475551837913475119) started by @clentfort*