### PR TITLE
Improve test coverage for EditIconButton

### DIFF
--- a/src/components/icon-buttons/edit.test.tsx
+++ b/src/components/icon-buttons/edit.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import EditIconButton from './edit';
+
+describe('EditIconButton', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('should render correctly and handle click events', async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+
+		render(<EditIconButton onClick={onClick} />);
+
+		const button = screen.getByRole('button', { name: /edit/i });
+		expect(button).toBeInTheDocument();
+
+		await user.click(button);
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
This change adds a new unit test for the `EditIconButton` component, which previously had 0% test coverage. 

Key changes:
- Created `src/components/icon-buttons/edit.test.tsx` to verify that the component:
    - Renders a button with the correct accessible label ("Edit").
    - Correctly calls the provided `onClick` handler when clicked.
- Achieved 100% statement and line coverage for `src/components/icon-buttons/edit.tsx`.
- Verified the integrity of the full unit test suite (all 473 tests passed).
- Ensured repository cleanliness by removing diagnostic artifacts generated during the coverage analysis.

---
*PR created automatically by Jules for task [13772880847464634051](https://jules.google.com/task/13772880847464634051) started by @clentfort*