### PR TITLE
Improve coverage for IndexedGrowthHistoryList

### DIFF
--- a/src/app/growth/components/indexed-growth-history-list.test.tsx
+++ b/src/app/growth/components/indexed-growth-history-list.test.tsx
@@ -4,7 +4,11 @@ import { Provider } from 'tinybase/ui-react';
 import { describe, expect, it, vi } from 'vitest';
 import { I18nContext } from '@/contexts/i18n-context';
 import { TinybaseIndexesProvider } from '@/contexts/tinybase-indexes-context';
-import { TABLE_IDS } from '@/lib/tinybase-sync/constants';
+import {
+	STORE_VALUE_SELECTED_PROFILE_ID,
+	STORE_VALUE_UNIT_SYSTEM,
+	TABLE_IDS,
+} from '@/lib/tinybase-sync/constants';
 import IndexedGrowthHistoryList from './indexed-growth-history-list';
 
 // Mock getToothName to avoid external dependencies
@@ -18,6 +22,8 @@ function createTestStore() {
 	// Add growth measurements
 	store.setRow(TABLE_IDS.GROWTH_MEASUREMENTS, 'growth-1', {
 		date: '2024-01-15T11:00:00Z',
+		headCircumference: 38,
+		height: 55,
 		weight: 4500,
 	});
 	store.setRow(TABLE_IDS.GROWTH_MEASUREMENTS, 'growth-2', {
@@ -131,5 +137,47 @@ describe('IndexedGrowthHistoryList', () => {
 		fireEvent.click(screen.getByText(/delete/i));
 
 		expect(screen.getByText(/no history recorded yet/i)).toBeDefined();
+	});
+
+	it('should render growth measurements and teeth correctly with metric system and a selected profile ID', () => {
+		const store = createStore();
+
+		// Set unit system to metric
+		store.setValue(STORE_VALUE_UNIT_SYSTEM, 'metric');
+		// Set selected profile ID
+		store.setValue(STORE_VALUE_SELECTED_PROFILE_ID, 'profile-1');
+
+		// Add growth measurement with height and head circumference under profile-1
+		store.setRow(TABLE_IDS.GROWTH_MEASUREMENTS, 'growth-metric-1', {
+			date: '2024-01-15T11:00:00Z',
+			headCircumference: 38,
+			height: 55,
+			notes: 'Growing well',
+			profileId: 'profile-1',
+			weight: 4500,
+		});
+
+		// Add teething entry under profile-1
+		store.setRow(TABLE_IDS.TEETHING, 'tooth-metric-51', {
+			date: '2024-01-15T10:00:00Z',
+			notes: 'First tooth',
+			profileId: 'profile-1',
+			toothId: 51,
+		});
+
+		render(
+			<Provider store={store}>
+				<TinybaseIndexesProvider>
+					<IndexedGrowthHistoryList />
+				</TinybaseIndexesProvider>
+			</Provider>,
+		);
+
+		// Check formatting in metric system
+		expect(screen.getByText(/4,500 g/i)).toBeDefined();
+		expect(screen.getByText(/55 cm/i)).toBeDefined();
+		expect(screen.getByText(/38 cm/i)).toBeDefined();
+		expect(screen.getByText(/Growing well/i)).toBeDefined();
+		expect(screen.getByText(/First tooth/i)).toBeDefined();
 	});
 });

--- a/src/app/growth/components/indexed-growth-history-list.test.tsx
+++ b/src/app/growth/components/indexed-growth-history-list.test.tsx
@@ -177,7 +177,7 @@ describe('IndexedGrowthHistoryList', () => {
 		expect(screen.getByText(/4,500 g/i)).toBeDefined();
 		expect(screen.getByText(/55 cm/i)).toBeDefined();
 		expect(screen.getByText(/38 cm/i)).toBeDefined();
-		expect(screen.getByText(/Growing well/i)).toBeDefined();
-		expect(screen.getByText(/First tooth/i)).toBeDefined();
+		expect(screen.getByText(/growing well/i)).toBeDefined();
+		expect(screen.getByText(/first tooth/i)).toBeDefined();
 	});
 });


### PR DESCRIPTION
Identified src/app/growth/components/indexed-growth-history-list.tsx as one of the functional components with the lowest coverage that is not currently addressed by open/existing branches, chart limitations, or migrations. Added target unit tests covering metric length formatting and profile-specific slicing, bringing its line coverage to 100% and statement coverage to 96.96%.

---
*PR created automatically by Jules for task [15420584254660451375](https://jules.google.com/task/15420584254660451375) started by @clentfort*