### PR TITLE
test: increase test coverage for get-frecency-sorted-products.ts to 100%

### DIFF
--- a/src/app/diaper/utils/get-frecency-sorted-products.test.ts
+++ b/src/app/diaper/utils/get-frecency-sorted-products.test.ts
@@ -97,4 +97,28 @@ describe('getFrecencySortedProducts', () => {
 		expect(sorted[0].id).toBe('2');
 		expect(sorted[1].id).toBe('1');
 	});
+
+	it('ignores diaper changes without a diaperProductId', () => {
+		const now = new Date();
+		const changes: DiaperChange[] = [
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: '1',
+				id: 'c1',
+				timestamp: subDays(now, 1).toISOString(),
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: undefined,
+				id: 'c2',
+				timestamp: subDays(now, 1).toISOString(),
+			},
+		];
+
+		// This should run without errors and treat Brand A (id: '1') as more used than Brand B (id: '2')
+		const sorted = getFrecencySortedProducts(products, changes);
+		expect(sorted[0].id).toBe('1');
+	});
 });


### PR DESCRIPTION
This PR increases the unit test coverage of `src/app/diaper/utils/get-frecency-sorted-products.ts` to exactly 100% Statements, Branches, Functions, and Lines. No production code was altered, only the test suite in `src/app/diaper/utils/get-frecency-sorted-products.test.ts` was extended with a targeted test verifying that diaper change history entries lacking a `diaperProductId` are ignored gracefully.

---
*PR created automatically by Jules for task [368140523551136370](https://jules.google.com/task/368140523551136370) started by @clentfort*