### PR TITLE
Improve test coverage for ReusableSavingsCard to 100%

### DIFF
--- a/src/app/statistics/components/reusable-savings-card.test.tsx
+++ b/src/app/statistics/components/reusable-savings-card.test.tsx
@@ -112,4 +112,294 @@ describe('ReusableSavingsCard', () => {
 			screen.queryByText('Reusable Diaper Metrics'),
 		).not.toBeInTheDocument();
 	});
+
+	it('calculates and shows estimated break-even date when savings are negative but contribution is positive', () => {
+		const estChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-1',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-reusable-1',
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+		]);
+
+		const estProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: 0.3,
+				id: 'product-disposable-1',
+				isReusable: false,
+				name: 'Disposable Hero',
+			},
+			{
+				costPerDiaper: 0.1,
+				id: 'product-reusable-1',
+				isReusable: true,
+				name: 'Reusable Hero',
+				upfrontCost: 10.0,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={estChanges}
+				products={estProducts}
+			/>,
+		);
+
+		expect(screen.getByText(/Est\./)).toBeInTheDocument();
+	});
+
+	it('shows not yet reached when break-even is not possible due to negative contribution', () => {
+		const cheapChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-cheap',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-reusable-expensive',
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+		]);
+
+		const cheapProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: 0.2,
+				id: 'product-disposable-cheap',
+				isReusable: false,
+				name: 'Cheap Disposable',
+			},
+			{
+				costPerDiaper: 0.5,
+				id: 'product-reusable-expensive',
+				isReusable: true,
+				name: 'Expensive Reusable',
+				upfrontCost: 10.0,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={cheapChanges}
+				products={cheapProducts}
+			/>,
+		);
+
+		expect(screen.getByText('Not yet reached')).toBeInTheDocument();
+	});
+
+	it('handles extreme/invalid product fields gracefully', () => {
+		const badChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-bad-upfront',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-bad-cost',
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: undefined,
+				timestamp: '2026-02-03T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'unknown-product',
+				timestamp: '2026-02-04T10:00:00.000Z',
+			},
+		]);
+
+		const badProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: Infinity,
+				id: 'product-bad-upfront',
+				isReusable: true,
+				name: 'Bad Upfront',
+				upfrontCost: NaN,
+			},
+			{
+				costPerDiaper: NaN,
+				id: 'product-bad-cost',
+				isReusable: true,
+				name: 'Bad Cost',
+				upfrontCost: 5.0,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={badChanges}
+				products={badProducts}
+			/>,
+		);
+
+		expect(screen.getByText('Reusable Diaper Metrics')).toBeInTheDocument();
+	});
+
+	it('sets breakEvenDate and breaks when running savings reach zero or more', () => {
+		const breakEvenChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-1',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-reusable-1',
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+		]);
+
+		const breakEvenProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: 1.0,
+				id: 'product-disposable-1',
+				isReusable: false,
+				name: 'Disposable Hero',
+			},
+			{
+				costPerDiaper: 0.2,
+				id: 'product-reusable-1',
+				isReusable: true,
+				name: 'Reusable Hero',
+				upfrontCost: 0.5,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={breakEvenChanges}
+				products={breakEvenProducts}
+			/>,
+		);
+
+		expect(screen.queryByText('Not yet reached')).not.toBeInTheDocument();
+		expect(screen.getByText(/Feb/)).toBeInTheDocument();
+	});
+
+	it('triggers edge cases for invalid disposable cost and infinite disposable cost', () => {
+		const edgeChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-nan',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-inf',
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-reusable-1',
+				timestamp: '2026-02-03T10:00:00.000Z',
+			},
+		]);
+
+		const edgeProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: NaN,
+				id: 'product-disposable-nan',
+				isReusable: false,
+				name: 'NaN Disposable',
+			},
+			{
+				costPerDiaper: Infinity,
+				id: 'product-disposable-inf',
+				isReusable: false,
+				name: 'Inf Disposable',
+			},
+			{
+				costPerDiaper: 0.1,
+				id: 'product-reusable-1',
+				isReusable: true,
+				name: 'Reusable Hero',
+				upfrontCost: 1.0,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={edgeChanges}
+				products={edgeProducts}
+			/>,
+		);
+
+		expect(screen.getByText('Reusable Diaper Metrics')).toBeInTheDocument();
+	});
+
+	it('triggers edge cases for potty stool and empty average disposable around potty events', () => {
+		const pottyChanges: DiaperChange[] = createDiaperChanges([
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-disposable-1',
+				timestamp: '2026-02-01T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: false,
+				pottyStool: true,
+				timestamp: '2026-02-02T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: false,
+				pottyUrine: true,
+				timestamp: '2026-02-20T10:00:00.000Z',
+			},
+			{
+				containsStool: false,
+				containsUrine: true,
+				diaperProductId: 'product-reusable-1',
+				timestamp: '2026-02-03T10:00:00.000Z',
+			},
+		]);
+
+		const pottyProducts: DiaperProduct[] = [
+			{
+				costPerDiaper: 0.3,
+				id: 'product-disposable-1',
+				isReusable: false,
+				name: 'Disposable Hero',
+			},
+			{
+				costPerDiaper: 0.1,
+				id: 'product-reusable-1',
+				isReusable: true,
+				name: 'Reusable Hero',
+				upfrontCost: 1.0,
+			},
+		];
+
+		render(
+			<ReusableSavingsCard
+				allDiaperChanges={pottyChanges}
+				products={pottyProducts}
+			/>,
+		);
+
+		expect(screen.getByText('Reusable Diaper Metrics')).toBeInTheDocument();
+	});
 });

--- a/src/app/statistics/components/reusable-savings-card.test.tsx
+++ b/src/app/statistics/components/reusable-savings-card.test.tsx
@@ -231,10 +231,10 @@ describe('ReusableSavingsCard', () => {
 				id: 'product-bad-upfront',
 				isReusable: true,
 				name: 'Bad Upfront',
-				upfrontCost: NaN,
+				upfrontCost: Number.NaN,
 			},
 			{
-				costPerDiaper: NaN,
+				costPerDiaper: Number.NaN,
 				id: 'product-bad-cost',
 				isReusable: true,
 				name: 'Bad Cost',
@@ -319,7 +319,7 @@ describe('ReusableSavingsCard', () => {
 
 		const edgeProducts: DiaperProduct[] = [
 			{
-				costPerDiaper: NaN,
+				costPerDiaper: Number.NaN,
 				id: 'product-disposable-nan',
 				isReusable: false,
 				name: 'NaN Disposable',


### PR DESCRIPTION
We identified src/app/statistics/components/reusable-savings-card.tsx as the file with the lowest test coverage (93.13%) among non-chart, non-migration files without active pull request branches. We added comprehensive unit tests to src/app/statistics/components/reusable-savings-card.test.tsx to fully cover all Statement, Branch, Function, and Line edge cases. Coverage has reached 100%.

---
*PR created automatically by Jules for task [15405840709760083017](https://jules.google.com/task/15405840709760083017) started by @clentfort*