### PR TITLE
Improve test coverage for useTodayDiaperStats

### DIFF
--- a/src/hooks/use-today-diaper-stats.test.tsx
+++ b/src/hooks/use-today-diaper-stats.test.tsx
@@ -79,4 +79,33 @@ describe('useTodayDiaperStats', () => {
 
 		expect(result.current).toEqual({ stoolCount: 0, urineCount: 0 });
 	});
+
+	it('should filter today diaper changes by selected profile id', () => {
+		const store = createTestStore();
+		const now = new Date();
+
+		store.setValue('selectedProfileId', 'profile-a');
+
+		// Match profile-a
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd1', {
+			containsUrine: true,
+			profileId: 'profile-a',
+			timestamp: now.toISOString(),
+		});
+
+		// Does not match profile-a
+		store.setRow(TABLE_IDS.DIAPER_CHANGES, 'd2', {
+			containsStool: true,
+			profileId: 'profile-b',
+			timestamp: now.toISOString(),
+		});
+
+		const { result } = renderHook(() => useTodayDiaperStats(), {
+			wrapper: ({ children }) => (
+				<TinyBaseTestWrapper store={store}>{children}</TinyBaseTestWrapper>
+			),
+		});
+
+		expect(result.current).toEqual({ stoolCount: 0, urineCount: 1 });
+	});
 });


### PR DESCRIPTION
Adds a single test case to improve the test coverage of the file with the lowest coverage (use-today-diaper-stats.ts) to 100% statements, branches, functions, and lines. No production code was altered.

---
*PR created automatically by Jules for task [631279964663144021](https://jules.google.com/task/631279964663144021) started by @clentfort*