### PR TITLE
Improve device ID utility test coverage to 100%

### DIFF
--- a/src/utils/device-id.test.ts
+++ b/src/utils/device-id.test.ts
@@ -38,4 +38,26 @@ describe('getDeviceId', () => {
 		const id = getDeviceId();
 		expect(id).toBe('server');
 	});
+
+	it('returns a fallback pseudo-random ID when crypto is undefined', () => {
+		vi.mocked(localStorage.getItem).mockReturnValue(null);
+		vi.stubGlobal('crypto', undefined);
+
+		const id = getDeviceId();
+
+		expect(id).toBeDefined();
+		expect(id).toMatch(/^device-[a-z0-9]+-[a-z0-9]+$/);
+		expect(localStorage.setItem).toHaveBeenCalledWith('deviceId', id);
+	});
+
+	it('returns a fallback pseudo-random ID when crypto exists but randomUUID is undefined', () => {
+		vi.mocked(localStorage.getItem).mockReturnValue(null);
+		vi.stubGlobal('crypto', {});
+
+		const id = getDeviceId();
+
+		expect(id).toBeDefined();
+		expect(id).toMatch(/^device-[a-z0-9]+-[a-z0-9]+$/);
+		expect(localStorage.setItem).toHaveBeenCalledWith('deviceId', id);
+	});
 });

--- a/src/utils/device-id.test.ts
+++ b/src/utils/device-id.test.ts
@@ -46,7 +46,7 @@ describe('getDeviceId', () => {
 		const id = getDeviceId();
 
 		expect(id).toBeDefined();
-		expect(id).toMatch(/^device-[a-z0-9]+-[a-z0-9]+$/);
+		expect(id).toMatch(/^device(?:-[\da-z]+){2}$/);
 		expect(localStorage.setItem).toHaveBeenCalledWith('deviceId', id);
 	});
 
@@ -57,7 +57,7 @@ describe('getDeviceId', () => {
 		const id = getDeviceId();
 
 		expect(id).toBeDefined();
-		expect(id).toMatch(/^device-[a-z0-9]+-[a-z0-9]+$/);
+		expect(id).toMatch(/^device(?:-[\da-z]+){2}$/);
 		expect(localStorage.setItem).toHaveBeenCalledWith('deviceId', id);
 	});
 });


### PR DESCRIPTION
Added unit tests to `src/utils/device-id.test.ts` to cover the fallback UUID generation branch when `crypto` or `crypto.randomUUID` is undefined. Verified that all unit tests pass and that coverage reaches 100% for the functional utility file.

---
*PR created automatically by Jules for task [3902097378106034047](https://jules.google.com/task/3902097378106034047) started by @clentfort*