### PR TITLE
Improve unit test coverage for YearlyActivityHeatMap to 100%

### DIFF
--- a/src/app/statistics/components/yearly-activity-heat-map.test.tsx
+++ b/src/app/statistics/components/yearly-activity-heat-map.test.tsx
@@ -92,4 +92,44 @@ describe('YearlyActivityHeatMap', () => {
 		const diaperDayCell = screen.getByTestId('yearly-cell-2024-01-02');
 		expect(diaperDayCell).toHaveClass('bg-amber-600');
 	});
+
+	it('renders without card wrapper when noCard prop is true', () => {
+		render(<YearlyActivityHeatMap dates={[]} noCard={true} />);
+		expect(screen.queryByText('Less')).toBeInTheDocument();
+	});
+
+	it('ignores invalid dates in input', () => {
+		render(<YearlyActivityHeatMap dates={['invalid-date']} />);
+		const todayCell = screen.getByTestId('yearly-cell-2024-06-15');
+		expect(todayCell).toHaveAttribute('title', 'June 15th, 2024: 0');
+	});
+
+	it('renders all 4 contribution levels and maximum count 100% ratio', () => {
+		render(
+			<YearlyActivityHeatMap
+				dates={[
+					'2024-01-02T01:00:00Z',
+					'2024-01-02T02:00:00Z',
+					'2024-01-02T03:00:00Z',
+					'2024-01-02T04:00:00Z', // 4 counts (maxCount)
+					'2024-01-03T01:00:00Z', // 1 count (ratio 0.25 -> level 1)
+					'2024-01-04T01:00:00Z',
+					'2024-01-04T02:00:00Z', // 2 counts (ratio 0.5 -> level 2)
+					'2024-01-05T01:00:00Z',
+					'2024-01-05T02:00:00Z',
+					'2024-01-05T03:00:00Z', // 3 counts (ratio 0.75 -> level 3)
+				]}
+			/>,
+		);
+
+		const maxCell = screen.getByTestId('yearly-cell-2024-01-02');
+		const level1Cell = screen.getByTestId('yearly-cell-2024-01-03');
+		const level2Cell = screen.getByTestId('yearly-cell-2024-01-04');
+		const level3Cell = screen.getByTestId('yearly-cell-2024-01-05');
+
+		expect(maxCell).toHaveClass('bg-left-breast');
+		expect(level1Cell).toHaveClass('bg-left-breast/15');
+		expect(level2Cell).toHaveClass('bg-left-breast/30');
+		expect(level3Cell).toHaveClass('bg-left-breast/55');
+	});
 });


### PR DESCRIPTION
This submission improves unit test coverage for `YearlyActivityHeatMap` (`src/app/statistics/components/yearly-activity-heat-map.tsx`) to 100% Statements, Branches, Functions, and Lines by expanding the test suite in `src/app/statistics/components/yearly-activity-heat-map.test.tsx` to cover missing branches and statements. No production code was altered.

---
*PR created automatically by Jules for task [16202566144036682521](https://jules.google.com/task/16202566144036682521) started by @clentfort*