### PR TITLE
Improve test coverage for feeding history list

### DIFF
--- a/src/app/feeding/components/feeding-history-list.test.tsx
+++ b/src/app/feeding/components/feeding-history-list.test.tsx
@@ -178,4 +178,24 @@ describe('FeedingHistoryList', () => {
 			screen.queryByText(/do you really want to delete this entry\?/i),
 		).not.toBeInTheDocument();
 	});
+
+	it('should handle undefined feeding session gracefully', () => {
+		const mockSession: FeedingSession = {
+			breast: 'left',
+			durationInSeconds: 600,
+			endTime: '2023-01-01T10:10:00Z',
+			id: 'test-session-missing',
+			startTime: '2023-01-01T10:00:00Z',
+		};
+
+		mockUseFeedingSession.mockReturnValue(undefined);
+
+		render(
+			<TestWrapper sessions={[mockSession]}>
+				<HistoryList onSessionDelete={() => {}} onSessionUpdate={() => {}} />
+			</TestWrapper>,
+		);
+
+		expect(screen.queryByTestId('feeding-history-entry')).not.toBeInTheDocument();
+	});
 });

--- a/src/app/feeding/components/feeding-history-list.test.tsx
+++ b/src/app/feeding/components/feeding-history-list.test.tsx
@@ -196,6 +196,8 @@ describe('FeedingHistoryList', () => {
 			</TestWrapper>,
 		);
 
-		expect(screen.queryByTestId('feeding-history-entry')).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('feeding-history-entry'),
+		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Improved test coverage for `src/app/feeding/components/feeding-history-list.tsx` by writing a unit test that validates the component handles `undefined` sessions gracefully. Statement, Line, and Function coverage for the file reached 100%. All unit tests, linters, and typechecks passed successfully.

---
*PR created automatically by Jules for task [339277058684741424](https://jules.google.com/task/339277058684741424) started by @clentfort*