### PR TITLE
Improve Branch Coverage for Diaper Frecency Sorting Utility

### DIFF
--- a/src/app/diaper/utils/get-frecency-sorted-product-ids.test.ts
+++ b/src/app/diaper/utils/get-frecency-sorted-product-ids.test.ts
@@ -13,7 +13,8 @@ describe('getFrecencySortedProductIds', () => {
 			'3': { name: 'Brand C' },
 			'4': { name: 'Brand D' },
 			'5': { name: 'Brand E' },
-			'6': { name: 123 }, // Testing non-string name fallback
+			'6': { name: 123 }, // Testing non-string name fallback (product B not string)
+			'7': { name: 456 }, // Testing non-string name fallback (product A not string)
 		};
 
 		const changes: DiaperChange[] = [
@@ -56,7 +57,7 @@ describe('getFrecencySortedProductIds', () => {
 				id: 'c5',
 				timestamp: subDays(now, 8).toISOString(),
 			},
-			// Product '5' and '6' never used (count 0, lastUsed 0)
+			// Product '5', '6', and '7' never used (count 0, lastUsed 0)
 			// Change with no productId (should be ignored)
 			{
 				containsStool: false,
@@ -68,8 +69,26 @@ describe('getFrecencySortedProductIds', () => {
 
 		const sortedIds = getFrecencySortedProductIds(productsById, changes);
 
-		// '6' has name 123, which becomes '' for localeCompare. '5' has name 'Brand E'.
-		// '' comes before 'Brand E'.
-		expect(sortedIds).toEqual(['2', '1', '3', '4', '6', '5']);
+		// '6' has name 123, '7' has name 456. Both are non-strings, which fall back to ''.
+		// '5' has name 'Brand E'.
+		// Since '6' and '7' both fallback to '', their order relative to each other in sort
+		// is stable or determined by their initial entry order. Both come before '5'.
+		expect(sortedIds).toEqual(['2', '1', '3', '4', '6', '7', '5']);
+	});
+
+	it('covers all branch pathways for name string checks', () => {
+		// Purely sorting by name (no changes)
+		// We want to force every pairwise comparison of (string, string), (string, non-string), (non-string, string), (non-string, non-string)
+		const productsById: Record<string, Row> = {
+			'1': { name: 123 },      // non-string
+			'2': { name: 'Brand Z' }, // string
+			'3': { name: 'Brand A' }, // string
+			'4': { name: undefined }, // non-string (missing)
+		};
+
+		const sortedIds = getFrecencySortedProductIds(productsById, []);
+		// '1' (falls back to '') and '4' (falls back to '') should sort before '3' and '2'.
+		// The exact output order is ['1', '4', '3', '2']
+		expect(sortedIds).toEqual(['1', '4', '3', '2']);
 	});
 });

--- a/src/app/diaper/utils/get-frecency-sorted-product-ids.test.ts
+++ b/src/app/diaper/utils/get-frecency-sorted-product-ids.test.ts
@@ -80,10 +80,10 @@ describe('getFrecencySortedProductIds', () => {
 		// Purely sorting by name (no changes)
 		// We want to force every pairwise comparison of (string, string), (string, non-string), (non-string, string), (non-string, non-string)
 		const productsById: Record<string, Row> = {
-			'1': { name: 123 },      // non-string
+			'1': { name: 123 }, // non-string
 			'2': { name: 'Brand Z' }, // string
 			'3': { name: 'Brand A' }, // string
-			'4': { name: undefined }, // non-string (missing)
+			'4': {}, // non-string (missing)
 		};
 
 		const sortedIds = getFrecencySortedProductIds(productsById, []);


### PR DESCRIPTION
Adds targeted unit tests to cover missing branch pathways for sorting diaper product IDs by frecency alphabetically when name properties are non-strings or missing completely. This increases coverage to 100% Statements, Branches, Functions, and Lines for `src/app/diaper/utils/get-frecency-sorted-product-ids.ts`.

---
*PR created automatically by Jules for task [12495615314997336587](https://jules.google.com/task/12495615314997336587) started by @clentfort*