### PR TITLE
test: improve coverage for FeedingsPerDayStats

### DIFF
--- a/src/app/statistics/components/feedings-per-day-stats.test.tsx
+++ b/src/app/statistics/components/feedings-per-day-stats.test.tsx
@@ -63,4 +63,22 @@ describe('FeedingsPerDayStats', () => {
 		render(<FeedingsPerDayStats sessions={singleSession} />);
 		expect(screen.getByText('1.0')).toBeInTheDocument();
 	});
+
+	it('renders comparison values correctly when comparisonSessions prop is provided', () => {
+		const comparisonSessions = createFeedingSessions([
+			{
+				breast: 'left',
+				durationInSeconds: 600,
+				startTime: '2023-12-25T10:00:00Z',
+			},
+		]);
+		render(
+			<FeedingsPerDayStats
+				comparisonSessions={comparisonSessions}
+				sessions={mockSessions}
+			/>,
+		);
+		expect(screen.getByText('1.7')).toBeInTheDocument();
+		expect(screen.getByText(/↑.*67%/)).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
Add unit test to src/app/statistics/components/feedings-per-day-stats.test.tsx to cover comparisonSessions prop, bringing line/branch/statement/function coverage for FeedingsPerDayStats to 100%.

---
*PR created automatically by Jules for task [8798920937203165611](https://jules.google.com/task/8798920937203165611) started by @clentfort*